### PR TITLE
fix problem with menus freezing on 3DS

### DIFF
--- a/src/Graphics_3DS.c
+++ b/src/Graphics_3DS.c
@@ -348,8 +348,7 @@ void Gfx_SetFpsLimit(cc_bool vsync, float minFrameMs) {
 }
 
 void Gfx_BeginFrame(void) {
-	int flags = gfx_vsync ? C3D_FRAME_SYNCDRAW : 0;
-	C3D_FrameBegin(flags);
+	C3D_FrameBegin(0);
 }
 
 void Gfx_Clear(void) {
@@ -363,7 +362,7 @@ void Gfx_EndFrame(void) {
 	//gfxSwapBuffers();
 
 	//Platform_LogConst("FRAME!");
-	//if (gfx_vsync) gspWaitForVBlank();
+	if (gfx_vsync) gspWaitForVBlank();
 	if (gfx_minFrameMs) LimitFPS();
 }
 


### PR DESCRIPTION
Entering some menus on 3DS while in-game will end up freezing the entire console when `C3D_FrameBegin` is called, and there doesn't appear to be any rhyme or reason for why this happens. Apparently using `gspWaitForVBlank` for vsync instead of passing the `C3D_FRAME_SYNCDRAW` flag to `C3D_FrameBegin` fixes the freezing issue. Note that if the user intentionally disables VSync, then the freezing issue will still occur.