### PR TITLE
Improvements for Flatpak build stuff

### DIFF
--- a/src/Core.h
+++ b/src/Core.h
@@ -120,9 +120,7 @@ typedef cc_uint8  cc_bool;
 
 #define CC_BUILD_NETWORKING
 #define CC_BUILD_FREETYPE
-#ifndef CC_BUILD_FLATPAK
 #define CC_BUILD_RESOURCES
-#endif
 /*#define CC_BUILD_GL11*/
 
 #ifndef CC_BUILD_MANUAL

--- a/src/Window_SDL3.c
+++ b/src/Window_SDL3.c
@@ -28,6 +28,9 @@ static void Window_SDLFail(const char* place) {
 
 void Window_Init(void) {
 	SDL_Init(SDL_INIT_VIDEO);
+	#ifdef CC_BUILD_FLATPAK
+	 SDL_SetHint(SDL_HINT_APP_ID, "net.classicube.flatpak.client");
+	#endif
 	int displayID = SDL_GetPrimaryDisplay();
 	Input.Sources = INPUT_SOURCE_NORMAL;
 	

--- a/src/Window_X11.c
+++ b/src/Window_X11.c
@@ -338,8 +338,13 @@ static void DoCreateWindow(int width, int height) {
 	
 	/* So right name appears in e.g. Ubuntu Unity launchbar */
 	XClassHint hint = { 0 };
-	hint.res_name   = GAME_APP_TITLE;
-	hint.res_class  = GAME_APP_TITLE;
+	#ifdef CC_BUILD_FLATPAK
+          hint.res_name   = "net.classicube.flatpak.client";
+          hint.res_class  = "net.classicube.flatpak.client";
+        #else
+	  hint.res_name   = GAME_APP_TITLE;
+          hint.res_class  = GAME_APP_TITLE;
+        #endif
 	XSetClassHint(win_display, win_handle, &hint);
 	ApplyIcon();
 


### PR DESCRIPTION
Changes:

(Re-)Enable resource downloading for Flatpak builds https://github.com/ClassiCube/ClassiCube/commit/eb531fe5fe8c8cfb98f7de875d62d886be0fd3d1

Use different class for Flatpak builds (Window_X11, class is set to `net.classicube.flatpak.client` with this) https://github.com/ClassiCube/ClassiCube/commit/de38ddb1d0e02e2487c6e346dbfeb23565663968, you should also set `StartupWMClass` to this, which is done in the Flatpak I am working on, speaking of:

Like mentioned above, I am working on a ClassiCube Flatpak, based off of @abb128's [work](https://github.com/abb128/flathub/tree/classicube) which sadly hasn't been updated in... let's say... a while, I haven't uploaded it yet but it should be ready soon and I will let you know when it is.

Also, thanks for making this cool project, gives me a very nostalgic feeling when I play, and it's open source :).

EDIT 1 (9:15 UTC i think): I have recorded a video of me playing ClassiCube with the Flatpak on KDE Plasma 6:


https://github.com/ClassiCube/ClassiCube/assets/80914457/9368d02b-b94a-4910-822d-f05c3f6b24a9

(sorry for the bad video quality, GitHub only allows 10mb videos :/)

EDIT 2: The Flatpak stuff is now uploaded here: https://github.com/sungsphinx/ClassiCubeFlatpak