### PR TITLE
GC/Wii audio backend

### DIFF
--- a/misc/gc/Makefile
+++ b/misc/gc/Makefile
@@ -33,7 +33,7 @@ LDFLAGS	=	-g $(MACHDEP) -Wl,-Map,$(notdir $@).map
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
-LIBS	:=	-lbba -lfat -logc -lm
+LIBS	:=	-lasnd -lbba -lfat -logc -lm
 
 #---------------------------------------------------------------------------------
 # no real need to edit anything past this point unless you need to add additional

--- a/misc/wii/Makefile
+++ b/misc/wii/Makefile
@@ -33,7 +33,7 @@ LDFLAGS	=	-g $(MACHDEP) -Wl,-Map,$(notdir $@).map
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
-LIBS	:=	-lwiikeyboard -lwiiuse -lbte -lfat -logc -lm
+LIBS	:=	-lasnd -lwiikeyboard -lwiiuse -lbte -lfat -logc -lm
 
 #---------------------------------------------------------------------------------
 # no real need to edit anything past this point unless you need to add additional

--- a/src/Core.h
+++ b/src/Core.h
@@ -288,7 +288,6 @@ typedef cc_uint8  cc_bool;
 	#undef  CC_BUILD_FREETYPE
 #elif defined GEKKO
 	#define CC_BUILD_GCWII
-	#define CC_BUILD_OPENAL
 	#define CC_BUILD_HTTPCLIENT
 	#define CC_BUILD_BEARSSL
 	#define CC_BUILD_COOPTHREADED


### PR DESCRIPTION
uses asndlib.h for audio on both GameCube and Wii (only the latter was tested on Dolphin)

music doesn't seem to work, but it's better than nothing