### PR TITLE
Rewrite sounds so that they are loaded from a zip instead

### DIFF
--- a/src/Audio.c
+++ b/src/Audio.c
@@ -335,7 +335,7 @@ static cc_result Music_Buffer(cc_int16* data, int maxSamples, struct VorbisState
 
 static cc_result Music_PlayOgg(struct Stream* source) {
 	struct OggState ogg;
-	struct VorbisState vorbis = { 0 };
+	struct VorbisState vorbis;
 	int channels, sampleRate, volume;
 
 	int chunkSize, samplesPerSecond;
@@ -344,6 +344,7 @@ static cc_result Music_PlayOgg(struct Stream* source) {
 	cc_result res;
 
 	Ogg_Init(&ogg, source);
+	Vorbis_Init(&vorbis);
 	vorbis.source = &ogg;
 	if ((res = Vorbis_DecodeHeaders(&vorbis))) goto cleanup;
 	

--- a/src/Audio.c
+++ b/src/Audio.c
@@ -95,7 +95,12 @@ static cc_result Sound_ReadWaveData(struct Stream* stream, struct Sound* snd) {
 			if ((res = Audio_AllocChunks(size, &snd->data, 1))) return res;
 
 			snd->size = size;
-			return Stream_Read(stream, (cc_uint8*)snd->data, size);
+			res = Stream_Read(stream, (cc_uint8*)snd->data, size);
+
+			#ifdef CC_BUILD_BIGENDIAN
+			Utils_SwapEndian16((cc_int16*)snd->data, size / 2);
+			#endif
+			return res;
 		}
 
 		/* Skip over unhandled data */

--- a/src/Audio.c
+++ b/src/Audio.c
@@ -17,6 +17,7 @@
 #include "Window.h"
 #endif
 int Audio_SoundsVolume, Audio_MusicVolume;
+const cc_string Sounds_DefaultZipPath = String_FromConst("audio/default.zip");
 static const cc_string audio_dir = String_FromConst("audio");
 
 struct Sound {

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -34,7 +34,8 @@ extern int Audio_SoundsVolume;
 /* Volume music is played at, from 0-100. */
 /* NOTE: Use Audio_SetMusic, don't change this directly. */
 extern int Audio_MusicVolume;
-extern const cc_string Sounds_DefaultZipPath;
+extern const cc_string Sounds_ZipPathMC;
+extern const cc_string Sounds_ZipPathCC;
 
 void Audio_SetMusic(int volume);
 void Audio_SetSounds(int volume);

--- a/src/Audio.h
+++ b/src/Audio.h
@@ -34,6 +34,7 @@ extern int Audio_SoundsVolume;
 /* Volume music is played at, from 0-100. */
 /* NOTE: Use Audio_SetMusic, don't change this directly. */
 extern int Audio_MusicVolume;
+extern const cc_string Sounds_DefaultZipPath;
 
 void Audio_SetMusic(int volume);
 void Audio_SetSounds(int volume);

--- a/src/ClassiCube.vcxproj.filters
+++ b/src/ClassiCube.vcxproj.filters
@@ -620,9 +620,6 @@
     <ClCompile Include="Platform_Dreamcast.c">
       <Filter>Source Files\Platform</Filter>
     </ClCompile>
-    <ClCompile Include="Window_Carbon.c">
-      <Filter>Source Files\Window</Filter>
-    </ClCompile>
     <ClCompile Include="Window_Android.c">
       <Filter>Source Files\Window</Filter>
     </ClCompile>
@@ -712,6 +709,9 @@
     </ClCompile>
     <ClCompile Include="Graphics_Xbox360.c">
       <Filter>Source Files\Graphics</Filter>
+    </ClCompile>
+    <ClCompile Include="AudioBackend.c">
+      <Filter>Source Files\Audio</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/LScreens.c
+++ b/src/LScreens.c
@@ -1012,9 +1012,11 @@ static void CheckResourcesScreen_Next(void* w) {
 }
 
 static void CheckResourcesScreen_AddWidgets(struct CheckResourcesScreen* s) {
+	const char* line1_msg = Resources_MissingRequired ? "Some required resources weren't found" 
+														: "Some optional resources weren't found";
 	s->lblStatus.small = true;
 
-	LLabel_Add(s,  &s->lblLine1,  "Some required resources weren't found", cres_lblLine1);
+	LLabel_Add(s,  &s->lblLine1,  line1_msg,           cres_lblLine1);
 	LLabel_Add(s,  &s->lblLine2,  "Okay to download?", cres_lblLine2);
 	LLabel_Add(s,  &s->lblStatus, "",                  cres_lblStatus);
 
@@ -1030,7 +1032,7 @@ static void CheckResourcesScreen_Activated(struct LScreen* s_) {
 	float size;
 	CheckResourcesScreen_AddWidgets(s);
 		
-	size = Resources_Size / 1024.0f;
+	size = Resources_MissingSize / 1024.0f;
 	String_InitArray(str, buffer);
 	String_Format1(&str, "&eDownload size: %f2 megabytes", &size);
 	LLabel_SetText(&s->lblStatus, &str);
@@ -1121,7 +1123,7 @@ static void FetchResourcesScreen_UpdateStatus(struct FetchResourcesScreen* s, in
 
 	String_InitArray(str, strBuffer);
 	count = Fetcher_Downloaded + 1;
-	String_Format3(&str, "&eFetching %c.. (%i/%i)", name, &count, &Resources_Count);
+	String_Format3(&str, "&eFetching %c.. (%i/%i)", name, &count, &Resources_MissingCount);
 
 	if (String_Equals(&str, &s->lblStatus.text)) return;
 	LLabel_SetText(&s->lblStatus, &str);

--- a/src/Launcher.c
+++ b/src/Launcher.c
@@ -260,7 +260,7 @@ void Launcher_Run(void) {
 #ifdef CC_BUILD_RESOURCES
 	Resources_CheckExistence();
 
-	if (Resources_Count) {
+	if (Resources_MissingCount) {
 		CheckResourcesScreen_SetActive();
 	} else {
 		MainScreen_SetActive();

--- a/src/Resources.c
+++ b/src/Resources.c
@@ -144,8 +144,11 @@ static cc_result SoundPatcher_WriteWav(struct Stream* s, struct VorbisState* ctx
 
 		count = Vorbis_OutputFrame(ctx, samples);
 		len  += count * 2;
-		/* TODO: Do we need to account for big endian */
-		res = Stream_Write(s, samples, count * 2);
+
+#ifdef CC_BUILD_BIGENDIAN
+		Utils_SwapEndian16(samples, count);
+#endif
+		res = Stream_Write(s, (cc_uint8*)samples, count * 2);
 		if (res) break;
 	}
 

--- a/src/Resources.c
+++ b/src/Resources.c
@@ -704,30 +704,28 @@ static const char* CCTextures_GetRequestName(int reqID) {
 /*########################################################################################################################*
 *-------------------------------------------------CC texture assets processing -------------------------------------------*
 *#########################################################################################################################*/
-#ifdef CC_BUILD_MOBILE
 /* Android needs the touch.png */
 /* TODO: Unify both android and desktop platforms to both just extract from default.zip */
 static cc_bool CCTextures_SelectEntry(const cc_string* path) {
 	return String_CaselessEqualsConst(path, "touch.png");
 }
+
 static cc_result CCTextures_ProcessEntry(const cc_string* path, struct Stream* data, struct ZipEntry* source) {
 	struct ResourceZipEntry* e = ZipEntries_Find(path);
+	if (!e) return 0; /* TODO exteact on PC too */
+
 	return ZipEntry_ExtractData(e, data, source);
 }
 
 static cc_result CCTextures_ExtractZip(struct HttpRequest* req) {
 	struct Stream src;
-	Stream_WriteAllTo(&ccTexPack, req->data, req->size);
-	Stream_ReadonlyMemory(&src,   req->data, req->size);
+	cc_result res;
 
-	return Zip_Extract(&src, 
-			CCTextures_SelectEntry, CCTextures_ProcessEntry);
-}
-#else
-static cc_result CCTextures_ExtractZip(struct HttpRequest* req) {
+	Stream_ReadonlyMemory(&src, req->data, req->size);
+	if ((res = Zip_Extract(&src, CCTextures_SelectEntry, CCTextures_ProcessEntry))) return res;
+
 	return Stream_WriteAllTo(&ccTexPack, req->data, req->size);
 }
-#endif
 
 static void CCTextures_CheckStatus(void) {
 	struct HttpRequest item;

--- a/src/Resources.h
+++ b/src/Resources.h
@@ -8,9 +8,11 @@ struct HttpRequest;
 typedef void (*FetcherErrorCallback)(struct HttpRequest* req);
 
 /* Number of resources that need to be downloaded */
-extern int Resources_Count;
+extern int Resources_MissingCount;
 /* Total size of resources that need to be downloaded */
-extern int Resources_Size;
+extern int Resources_MissingSize;
+/* Whether required resources need to be downloaded */
+extern cc_bool Resources_MissingRequired;
 /* Checks existence of all assets */
 void Resources_CheckExistence(void);
 

--- a/src/Utils.c
+++ b/src/Utils.c
@@ -138,6 +138,19 @@ void Utils_Resize(void** buffer, int* capacity, cc_uint32 elemSize, int defCapac
 	}
 }
 
+void Utils_SwapEndian16(cc_int16* values, int numValues) {
+	cc_uint8* data = (cc_uint8*)values;
+	int i;
+
+	for (i = 0; i < numValues * 2; i += 2)
+	{
+		cc_uint8 tmp = data[i + 0];
+		data[i + 0]  = data[i + 1];
+		data[i + 1]  = tmp;
+	}
+}
+
+
 static const char base64_table[64] = {
 	'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P',
 	'Q','R','S','T','U','V','W','X','Y','Z','a','b','c','d','e','f',

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -45,6 +45,7 @@ cc_uint32 Utils_CRC32(const cc_uint8* data, cc_uint32 length);
 /* NOTE: This cannot be just indexed by byte value - see Utils_CRC32 implementation. */
 extern const cc_uint32 Utils_Crc32Table[256];
 CC_NOINLINE void Utils_Resize(void** buffer, int* capacity, cc_uint32 elemSize, int defCapacity, int expandElems);
+void Utils_SwapEndian16(cc_int16* values, int numValues);
 
 /* Converts blocks of 3 bytes into 4 ASCII characters. (pads if needed) */
 /* Returns the number of ASCII characters written. */

--- a/src/Vorbis.c
+++ b/src/Vorbis.c
@@ -1229,6 +1229,10 @@ static void Vorbis_CalcWindow(struct VorbisWindow* window, int blockSize) {
 	}
 }
 
+void Vorbis_Init(struct VorbisState* ctx) {
+	Mem_Set(ctx, 0, sizeof(*ctx) - sizeof(ctx->imdct));
+}
+
 void Vorbis_Free(struct VorbisState* ctx) {
 	int i;
 	for (i = 0; i < ctx->numCodebooks; i++) 

--- a/src/Vorbis.h
+++ b/src/Vorbis.h
@@ -56,7 +56,9 @@ struct VorbisState {
 	struct imdct_state imdct[2];
 };
 
-/* Frees all dynamic memory allocated to decode the given vorbis audio. */
+/* Initialises the given context to defaults */
+void Vorbis_Init(struct VorbisState* ctx);
+/* Frees all memory dynamically allocated by the given context */
 void Vorbis_Free(struct VorbisState* ctx);
 /* Reads and decodes the initial vorbis headers and setup data. */
 cc_result Vorbis_DecodeHeaders(struct VorbisState* ctx);


### PR DESCRIPTION
This makes it possible to provide a fallback `audio/classicube.zip` file for sounds