### PR TITLE
Stop new chat from affecting chat position when scrolled up and looking at chat history.

### DIFF
--- a/src/Screens.c
+++ b/src/Screens.c
@@ -1073,6 +1073,9 @@ static void ChatScreen_ChatReceived(void* screen, const cc_string* msg, int type
 	s->dirty = true;
 
 	if (type == MSG_TYPE_NORMAL) {
+		/* Check if the chatIndex isn't located at the bottom of the chat log, that means that the user has scrolled.  */
+		if (Chat_Log.count - s->chatIndex != Gui.Chatlines + 1) return;
+
 		s->chatIndex++;
 		if (!Gui.Chatlines) return;
 		TextGroupWidget_ShiftUp(&s->chat);


### PR DESCRIPTION
Fixes  #329 by checking on `ChatScreen_ChatReceived` if the chat index is currently at the bottom, if not, it won't cause it to shift upwards.