### PR TITLE
PSP: Don't use a cc_socket pointer for Inet functions

### DIFF
--- a/src/Platform_PSP.c
+++ b/src/Platform_PSP.c
@@ -327,7 +327,7 @@ cc_result Socket_Create(cc_socket* s, cc_sockaddr* addr, cc_bool nonblocking) {
 cc_result Socket_Connect(cc_socket s, cc_sockaddr* addr) {
 	struct sockaddr* raw = (struct sockaddr*)addr->data;
 	
-	int res = sceNetInetConnect(*s, raw, addr->size);
+	int res = sceNetInetConnect(s, raw, addr->size);
 	return res < 0 ? sceNetInetGetErrno() : 0;
 }
 


### PR DESCRIPTION
The sceNetInet*() functions don't use a pointer for the socket: https://docs.rs/psp/latest/psp/sys/fn.sceNetInetConnect.html https://docs.rs/psp/latest/psp/sys/fn.sceNetInetSocket.html

This fixes a compile error for the PSP builds (and makes the pipeline status green again) 🐸