### PR TITLE
Fixed Dreamcast build isues with latest GCC14.1.0

### DIFF
--- a/src/Graphics_Dreamcast.c
+++ b/src/Graphics_Dreamcast.c
@@ -342,7 +342,7 @@ static GfxResourceID Gfx_AllocTexture(struct Bitmap* bmp, int rowWidth, cc_uint8
 	int width, height;
 	gldcGetTexture(&pixels, &width, &height);
 	ConvertTexture(pixels, bmp, rowWidth);
-	return texId;
+	return (GfxResourceID)texId;
 }
 
 // TODO: struct GPUTexture ??
@@ -372,7 +372,7 @@ static void ConvertSubTexture(cc_uint16* dst, int texWidth, int texHeight,
 }
 
 void Gfx_UpdateTexture(GfxResourceID texId, int x, int y, struct Bitmap* part, int rowWidth, cc_bool mipmaps) {
-	gldcBindTexture(texId);
+	gldcBindTexture((GLuint)texId);
 				
 	void* pixels;
 	int width, height;


### PR DESCRIPTION
Hello guys,

I'm one of the developers behind the KallistiOS SDK for the Sega Dreamcast which is used by the DC back-end. I finally got around to checking out this project and building it from source; however, I'm going to guess that it's typically being built with an older GCC version, because I get a few trivial little implicit conversion build errors on the latest GCC14.1.0 toolchain. Thought I'd offer the fix real quick. 

- Apparently the latest GCC14.1.0 got stricter about integer/pointer conversions.
- Fixed two functions which failed to build due to implicitly converting between typedefs to unsigned and void* by adding explicit casts.