### PR TITLE
DC: INIT_FLAGS, optimization flags, dual analog

### DIFF
--- a/misc/dreamcast/Makefile
+++ b/misc/dreamcast/Makefile
@@ -5,7 +5,7 @@ TARGET 		:= ClassiCube-dc
 S_FILES := $(foreach dir,$(SOURCE_DIRS),$(wildcard $(dir)/*.S))
 C_FILES := $(foreach dir,$(SOURCE_DIRS),$(wildcard $(dir)/*.c))
 OBJS 	:= $(addprefix $(BUILD_DIR)/, $(notdir $(C_FILES:%.c=%.o) $(S_FILES:%.S=%.o)))
-CFLAGS	:= -g -O2 -pipe -fno-math-errno -Ithird_party/bearssl/inc
+CFLAGS	:= -g -DNDEBUG -O3 -fipa-pta -fno-pie -flto=auto -fomit-frame-pointer -fbuiltin -ffast-math -ffp-contract=fast -mfsrra -mfsca -pipe -fno-math-errno -Ithird_party/bearssl/inc
 
 # Dependency tracking
 DEPFLAGS = -MT $@ -MMD -MP -MF $(BUILD_DIR)/$*.d

--- a/src/Platform_Dreamcast.c
+++ b/src/Platform_Dreamcast.c
@@ -23,7 +23,9 @@
 #include <fat/fs_fat.h>
 #include <kos/dbgio.h>
 #include "_PlatformConsole.h"
-KOS_INIT_FLAGS(INIT_DEFAULT | INIT_NET);
+
+KOS_INIT_FLAGS(INIT_CONTROLLER | INIT_KEYBOARD | INIT_MOUSE |
+			   INIT_VMU        | INIT_CDROM    | INIT_NET);
 
 const cc_result ReturnCode_FileShareViolation = 1000000000; // not used
 const cc_result ReturnCode_FileNotFound     = ENOENT;

--- a/src/Platform_Dreamcast.c
+++ b/src/Platform_Dreamcast.c
@@ -25,7 +25,7 @@
 #include "_PlatformConsole.h"
 
 KOS_INIT_FLAGS(INIT_CONTROLLER | INIT_KEYBOARD | INIT_MOUSE |
-			   INIT_VMU        | INIT_CDROM    | INIT_NET);
+               INIT_VMU        | INIT_CDROM    | INIT_NET);
 
 const cc_result ReturnCode_FileShareViolation = 1000000000; // not used
 const cc_result ReturnCode_FileNotFound     = ENOENT;

--- a/src/Window_Dreamcast.c
+++ b/src/Window_Dreamcast.c
@@ -258,12 +258,19 @@ static void HandleJoystick(int port, int axis, int x, int y, float delta) {
 	Gamepad_SetAxis(port, axis, x / AXIS_SCALE, y / AXIS_SCALE, delta);
 }
 
-static void HandleController(int port, cont_state_t* state, float delta) {
+static void HandleController(int port, bool dual_analog, cont_state_t* state, float delta) {
 	Gamepad_SetButton(port, CCPAD_L, state->ltrig > 10);
 	Gamepad_SetButton(port, CCPAD_R, state->rtrig > 10);
-	// TODO second joystick
 	// TODO: verify values are right     
-	HandleJoystick(port, PAD_AXIS_RIGHT, state->joyx, state->joyy, delta);
+	if(dual_analog) 
+	{
+		HandleJoystick(port, PAD_AXIS_LEFT, state->joyx, state->joyy, delta);
+		HandleJoystick(port, PAD_AXIS_RIGHT, state->joy2x, state->joy2y, delta);
+	}
+	else
+	{
+		HandleJoystick(port, PAD_AXIS_RIGHT, state->joyx, state->joyy, delta);
+	}
 }
 
 void Gamepads_Process(float delta) {
@@ -276,9 +283,12 @@ void Gamepads_Process(float delta) {
 		if (!cont)  return;
 		state = (cont_state_t*)maple_dev_status(cont);
 		if (!state) return;
-		
+
+		int dual_analog = cont_has_capabilities(cont, CONT_CAPABILITIES_DUAL_ANALOG);
+		if(dual_analog == -1) dual_analog = 0;
+
 		HandleButtons(port, state->buttons);
-		HandleController(port, state, delta);
+		HandleController(port, dual_analog, state, delta);
 	}
 }
 


### PR DESCRIPTION

1) Hand-tuned KOS_INIT_FLAGS() to only include what was actually needed
   (shaving off ~50KB for a GCC14 relese build).
2) Set optimization to best known flags in DC-specific Makefile.
3) Implemented dual-analog stick support when detected.

PLEASE NOTE: I have still been unable to test my changes. Remote debugging via the BBA has issues when used with `INIT_NET`, which I have to figure out, plus I'm not sure why the .CDI isn't booting for me... just fyi. Might want to test these changes locally. Yes, I will work on fixing my builds, so I can test here.