### PR TITLE
Fix SDL3 backend with latest SDL3 commits

### DIFF
--- a/src/Window_SDL3.c
+++ b/src/Window_SDL3.c
@@ -68,7 +68,7 @@ static void DoCreateWindow(int width, int height, int flags) {
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, SDL_WINDOWPOS_CENTERED);
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER,  width);
 	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, height);
-	SDL_SetNumberProperty(props, "flags", flags | SDL_WINDOW_RESIZABLE);
+	SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER, flags | SDL_WINDOW_RESIZABLE);
 
 	win_handle = SDL_CreateWindowWithProperties(props);
 	if (!win_handle) Window_SDLFail("creating window");


### PR DESCRIPTION
They have changed flags property from `"flags"` to `SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER` causing window flags to never be set which causes the window to not be resizeable and ClassiCube not launching.