### PR TITLE
Disable save level button on Classic mode when in multiplayer

### DIFF
--- a/src/Menus.c
+++ b/src/Menus.c
@@ -615,6 +615,9 @@ static void ClassicPauseScreen_Init(void* screen) {
 	if (Server.IsSinglePlayer) return;
 	s->btns[1].flags = WIDGET_FLAG_DISABLED;
 	s->btns[3].flags = WIDGET_FLAG_DISABLED;
+
+	if (Game_ClassicHacks) return;
+	s->btns[2].flags = WIDGET_FLAG_DISABLED;
 }
 
 static const struct ScreenVTABLE ClassicPauseScreen_VTABLE = {


### PR DESCRIPTION
The "Save level.." button was disabled in original Classic on multiplayer, basic fix to disable it for exclusively Classic mode, will still work in Classic + Hax mode and Enhanced mode.