### PR TITLE
Place dirt under generated trees

### DIFF
--- a/src/Generator.c
+++ b/src/Generator.c
@@ -809,9 +809,13 @@ int TreeGen_Grow(int treeX, int treeY, int treeZ, int height, IVec3* coords, Blo
 		}
 	}
 
-	/* then place trunk */
+	/* place trunk */
 	for (y = 0; y < height - 1; y++) {
 		TreeGen_Place(treeX, treeY + y, treeZ, BLOCK_LOG);
 	}
+
+	/* then place dirt */
+	TreeGen_Place(treeX, treeY - 1, treeZ, BLOCK_DIRT);
+
 	return count;
 }


### PR DESCRIPTION
In Minecraft Classic 0.30 when a tree is generated (Either through a sapling or during world creation) the block it was growing on turns to dirt, this doesn't happen in ClassiCube and that's what this fix does.