### PR TITLE
Don't save camera's pitch axis when making a checkpoint

### DIFF
--- a/src/Entity.c
+++ b/src/Entity.c
@@ -883,7 +883,7 @@ static cc_bool LocalPlayer_HandleSetSpawn(int key, struct InputDevice* device) {
 		}
 		
 		p->SpawnYaw   = p->Base.Yaw;
-		p->SpawnPitch = p->Base.Pitch;
+		if (!Game_ClassicMode) p->SpawnPitch = p->Base.Pitch;
 	}
 	return LocalPlayer_HandleRespawn(key, device);
 }


### PR DESCRIPTION
In original Minecraft Classic, the camera's pitch axis wasn't saved when creating/loading checkpoints, this fixes that for Classic Mode.

~~(I don't know if it was possible to modify camera orientation in original Minecraft Classic with plugins and I won't be able to check for a while, could somebody get that checked and block plugins from doing that whilst in Classic Mode if that is the case)~~