### PR TITLE
Prevent saving of maps if MOTD contains -save

### DIFF
--- a/src/EntityComponents.c
+++ b/src/EntityComponents.c
@@ -235,6 +235,7 @@ void HacksComp_RecheckFlags(struct HacksComp* hacks) {
 	HacksComp_ParseFlag(hacks, "+push",        "-push",        &hacks->CanBePushed);
 	HacksComp_ParseFlag(hacks, "+thirdperson", "-thirdperson", &hacks->CanUseThirdPerson);
 	HacksComp_ParseFlag(hacks, "+names",       "-names",       &hacks->CanSeeAllNames);
+	HacksComp_ParseFlag(hacks, "+save",        "-save",        &hacks->CanSaveMap);
 
 	if (hacks->IsOp) HacksComp_ParseAllFlag(hacks, "+ophax", "-ophax");
 	hacks->BaseHorSpeed = HacksComp_ParseFlagFloat("horspeed=", hacks);

--- a/src/EntityComponents.h
+++ b/src/EntityComponents.h
@@ -52,8 +52,8 @@ struct HacksComp {
 	cc_bool Enabled;
 
 	cc_bool CanAnyHacks, CanUseThirdPerson, CanSpeed, CanFly;
-	cc_bool CanRespawn, CanNoclip, CanPushbackBlocks,CanSeeAllNames;
-	cc_bool CanDoubleJump, CanBePushed;
+	cc_bool CanRespawn, CanNoclip, CanPushbackBlocks, CanSeeAllNames;
+	cc_bool CanDoubleJump, CanBePushed, CanSaveMap;
 	float BaseHorSpeed;
 	/* Max amount of jumps the player can perform */
 	int MaxJumps;

--- a/src/Menus.c
+++ b/src/Menus.c
@@ -615,6 +615,8 @@ static void ClassicPauseScreen_Init(void* screen) {
 	if (Server.IsSinglePlayer) return;
 	s->btns[1].flags = WIDGET_FLAG_DISABLED;
 	s->btns[3].flags = WIDGET_FLAG_DISABLED;
+
+	if (!Entities.CurPlayer->Hacks.CanSaveMap) s->btns[5].flags = WIDGET_FLAG_DISABLED;
 }
 
 static const struct ScreenVTABLE ClassicPauseScreen_VTABLE = {


### PR DESCRIPTION
This change:
1. Prevents players from stealing maps for use on their own servers without permission.
2. Prevents players from cheating on maps by saving them and checking for things in singleplayer.