### PR TITLE
Disable scrolling for Classic chat

### DIFF
--- a/src/Screens.c
+++ b/src/Screens.c
@@ -1003,6 +1003,10 @@ static int ChatScreen_ClampChatIndex(int index) {
 }
 
 static void ChatScreen_ScrollChatBy(struct ChatScreen* s, int delta) {
+	if (Gui.ClassicChat) {
+		return;
+	}
+
 	int newIndex = ChatScreen_ClampChatIndex(s->chatIndex + delta);
 	delta = newIndex - s->chatIndex;
 


### PR DESCRIPTION
In the original Minecraft Classc 0.30, you weren't able to scroll up or down in the chat, this disables the scrolling functionality if the classic chat is being used (So when you are in Classic mode or using the classic chat option in Enhanced)