### PR TITLE
Redraw server list when new flags are fetched

### DIFF
--- a/src/LScreens.c
+++ b/src/LScreens.c
@@ -1342,8 +1342,15 @@ static void ServersScreen_Activated(struct LScreen* s_) {
 
 static void ServersScreen_Tick(struct LScreen* s_) {
 	struct ServersScreen* s = (struct ServersScreen*)s_;
+	int flagsCount;
 	LScreen_Tick(s_);
+
+	flagsCount = FetchFlagsTask.count;
 	LWebTask_Tick(&FetchFlagsTask.Base, NULL);
+
+	if (flagsCount != FetchFlagsTask.count) {
+		LBackend_NeedsRedraw(&s->table);
+	}
 
 	if (!FetchServersTask.Base.working) return;
 	LWebTask_Tick(&FetchServersTask.Base, NULL);


### PR DESCRIPTION
Currently, when the server list is fetched and displayed, country flags appear blank until the user interacts with the list by clicking, scrolling, etc. This change redraws the server list whenever new flags are fetched.
![cc](https://github.com/user-attachments/assets/b93f9848-2768-4ca3-bbf8-b86acfa2e9a9)