### PR TITLE
iOS: Add support for higher framerates on ProMotion devices

### DIFF
--- a/misc/ios/Info.plist
+++ b/misc/ios/Info.plist
@@ -137,5 +137,7 @@
 			</dict>
 		</dict>
 	</array>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/src/Game.c
+++ b/src/Game.c
@@ -75,6 +75,9 @@ int Game_NumStates = 1;
 
 const char* const FpsLimit_Names[FPS_LIMIT_COUNT] = {
 	"LimitVSync", "Limit30FPS", "Limit60FPS", "Limit120FPS", "Limit144FPS", "LimitNone",
+#ifdef CC_BUILD_IOS
+	"LimitProMotion",
+#endif
 };
 
 static struct IGameComponent* comps_head;
@@ -490,6 +493,10 @@ void Game_SetFpsLimit(int method) {
 	case FPS_LIMIT_30:  minFrameTime = 1000/30.0f;  break;
 	}
 	Gfx_SetVSync(method == FPS_LIMIT_VSYNC);
+#ifdef CC_BUILD_IOS
+	extern void Gfx_SetProMotion(cc_bool);
+	Gfx_SetProMotion(method == FPS_LIMIT_PROMOTION);
+#endif
 	Game_SetMinFrameTime(minFrameTime);
 }
 

--- a/src/Game.h
+++ b/src/Game.h
@@ -84,7 +84,11 @@ extern struct GameVersion Game_Version;
 extern void GameVersion_Load(void);
 
 enum FpsLimitMethod {
-	FPS_LIMIT_VSYNC, FPS_LIMIT_30, FPS_LIMIT_60, FPS_LIMIT_120, FPS_LIMIT_144, FPS_LIMIT_NONE, FPS_LIMIT_COUNT
+	FPS_LIMIT_VSYNC, FPS_LIMIT_30, FPS_LIMIT_60, FPS_LIMIT_120, FPS_LIMIT_144, FPS_LIMIT_NONE,
+#ifdef CC_BUILD_IOS
+	FPS_LIMIT_PROMOTION,
+#endif
+	FPS_LIMIT_COUNT
 };
 extern const char* const FpsLimit_Names[FPS_LIMIT_COUNT];
 

--- a/src/MenuOptions.c
+++ b/src/MenuOptions.c
@@ -775,7 +775,11 @@ static void GraphicsOptionsScreen_InitWidgets(struct MenuOptionsScreen* s) {
 			"&eVSync: &fNumber of frames rendered is at most the monitor's refresh rate.\n" \
 			"&e30/60/120/144 FPS: &fRenders 30/60/120/144 frames at most each second.\n" \
 			"&eNoLimit: &fRenders as many frames as possible each second.\n" \
-			"&cNoLimit is pointless - it wastefully renders frames that you don't even see!");
+			"&cNoLimit is pointless - it wastefully renders frames that you don't even see!"
+#ifdef CC_BUILD_IOS
+			"\n&eProMotion: &fRender above 60Hz on devices with ProMotion."
+#endif
+			);
 		MenuOptionsScreen_AddInt(s, "View distance",
 			8, 4096, 512,
 			GrO_GetViewDist,   GrO_SetViewDist, NULL);


### PR DESCRIPTION
This PR adds a new FPS limit option, LimitProMotion exclusive to iOS devices to make use of higher refresh rate ranges of ProMotion (up to 120Hz) on supported devices (iPhone 13 Pro and above). This is done by making a dummy CADisplayLink callback to hint iOS to set our refresh rate above 60Hz.

Due to the weirdness of ProMotion, there is no way to programmatically force 120Hz despite setting preferredFrameRateRange as such, and this is explicitly stated by Apple as well. On iPhone 15 Pro Max running iOS 18.1b5, I usually only reach up to 80Hz in normal settings. This may have to do with the iOS 18 update, which makes ProMotion much more conservative and locks most things to 80Hz. This might work a lot better on iOS 15-17, but I can't say for sure. For now, an extremely ugly workaround to guarantee the full 120Hz is to have screen recording running on the side (yes, really).

Your mileage with LimitProMotion may wary, so I made it a separate FPS limit option rather than having it work under LimitVsync.

If anybody else has the setup to test this particular feature, it would be really cool if you could share your results in this discussion.