### PR TITLE
Implement LINK variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,9 @@ else
 	CFLAGS += -g
 endif
 
+# link with CC by default
+LINK ?= $(CC)
+
 default: $(PLAT)
 
 web:
@@ -253,7 +256,7 @@ clean:
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 $(ENAME): $(BUILD_DIR) $(OBJECTS)
-	$(CC) $(LDFLAGS) -o $@$(OEXT) $(OBJECTS) $(EXTRA_LIBS) $(LIBS)
+	$(LINK) $(LDFLAGS) -o $@$(OEXT) $(OBJECTS) $(EXTRA_LIBS) $(LIBS)
 
 
 # macOS app bundle


### PR DESCRIPTION
This enables `$(CXX)` linking by default on targets that use the `LINK` variable to link/compile.

`_Unwind` is included with LLVM on OpenBSD, so we can actually use it with this `$(CXX)` linker/compiler patch instead of disabling it.

This also makes for a more extensible situation for platforms. If in the future we want to add more platforms that support `_Unwind` via linking with `$(CXX)` and/or a modern compiler, this `LINK` variable can help in those cases as well.

EDIT:

OpenBSD actually *doesn't* need `$(CXX)` as it links against `backtrace` from `-lexecinfo`, keeping `LINK` here but removed the override in the OpenBSD target.