### PR TITLE
Fill left options column first

### DIFF
--- a/src/MenuOptions.c
+++ b/src/MenuOptions.c
@@ -239,7 +239,7 @@ static int MenuOptionsScreen_AddButton(struct MenuOptionsScreen* s, const char* 
 
 static void MenuOptionsScreen_EndButtons(struct MenuOptionsScreen* s, Widget_LeftClick backClick) {
 	struct ButtonWidget* btn;
-	int i, col, row, half = s->numButtons / 2;
+	int i, col, row, half = (s->numButtons + 1) / 2;
 	int begRow = 2 - half;
 	if (s->numButtons & 1) begRow--;
 	begRow = max(-3, begRow);


### PR DESCRIPTION
This changes the options menu to look like in classic when the number of options is odd. I also think this layout looks more natural.
<details>
<summary>Comparison</summary>
<h2>Before</h2>
<img src=https://github.com/user-attachments/assets/64571ebe-93d0-4fd3-8362-0af5c063b9ec>
<h2>After</h2>
<img src=https://github.com/user-attachments/assets/aa655e82-0c53-485d-a519-c4346f10bbab>
<h2>How it looks in classic</h2>
<img src=https://github.com/user-attachments/assets/1830af4b-77c5-4899-a233-ef8198fdaf19>
</details>