### PR TITLE
Make a sprite block's hotbar texture be able to use a texture not shown while holding it

### DIFF
--- a/src/IsometricDrawer.c
+++ b/src/IsometricDrawer.c
@@ -37,7 +37,7 @@ static TextureLoc IsometricDrawer_GetTexLoc(BlockID block, Face face) {
 
 static void IsometricDrawer_Flat(BlockID block, float size) {
 	int texIndex;
-	TextureLoc loc = Block_Tex(block, FACE_ZMAX);
+	TextureLoc loc = Block_Tex(block, FACE_ZMIN);
 	TextureRec rec = Atlas1D_TexRec(loc, 1, &texIndex);
 
 	struct VertexTextured* v;


### PR DESCRIPTION
Makes a sprite block's hotbar texture use its front texture so it can use a texture that isn't shown while holding it