### PR TITLE
Change job name on file `build_msdos.yml`

### DIFF
--- a/.github/workflows/build_msdos.yml
+++ b/.github/workflows/build_msdos.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-mac-classic:
+  build-msdos:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/volkertb/debian-djgpp


### PR DESCRIPTION
The name of the job shouldn't be called "build-mac-classic", it's confusing.