### PR TITLE
Remove environment variable overrides in DS build script

### DIFF
--- a/.github/workflows/build_nds.yml
+++ b/.github/workflows/build_nds.yml
@@ -23,8 +23,6 @@ jobs:
         run: |
           apt-get update
           apt-get -y install curl
-          export BLOCKSDS=/opt/blocksds/core
-          export BLOCKSDSEXT=/opt/blocksds/external
           make ds
           export BUILD_DSI=1
           make ds


### PR DESCRIPTION
This should fix the Nintendo DS GitHub Actions build