### PR TITLE
[3DS] spec.rsf: set SystemMode to 80MB

### DIFF
--- a/misc/3ds/spec.rsf
+++ b/misc/3ds/spec.rsf
@@ -46,7 +46,7 @@ AccessControlInfo:
   AffinityMask                  : 1
   
   Priority                      : 16
-   
+  SystemMode                    : 80MB 
   MaxCpu                        : 0x9E # Default
   DisableDebug                  : false
   EnableForceDebug              : false


### PR DESCRIPTION
This allocates more memory to the game on Old 3DS, and helps a few more servers to run, or at least crash less. The possible values are 64MB (default), 96MB, 80MB, 72MB, and 32MB. I tried 96MB but it causes the home menu process to crash upon starting the game, even when disabling unneeded services in the RSF. Probably it needs some setup from the game code.
There isn't much documentation on these, I guess it would involve just asking people.