### PR TITLE
Support Modern macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,11 @@ ifeq ($(PLAT),darwin)
 	LDFLAGS =  -rdynamic -framework Cocoa -framework OpenGL -framework IOKit -lobjc
 	BUILD_DIR = build-macos
 	TARGET  = $(ENAME).app
+	
+	MACOS_VERSION = $(shell sw_vers -productVersion | cut -d. -f1)
+	ifeq ($(shell expr $(MACOS_VERSION) \>= 12), 1)
+		LDFLAGS += -framework UniformTypeIdentifiers
+	endif
 endif
 
 ifeq ($(PLAT),freebsd)

--- a/src/Window_cocoa.m
+++ b/src/Window_cocoa.m
@@ -750,7 +750,7 @@ static void DoDrawFramebuffer(NSRect dirty) {
 	// TODO: Find a better way of doing this in cocoa..
 	if (!fb_bmp.scan0) return;
 	nsContext = [NSGraphicsContext currentContext];
-#if defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+#if defined MAC_OS_X_VERSION_10_14 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_14
 	context   = [nsContext CGContext];
 #else
 	context   = [nsContext graphicsPort];
@@ -812,8 +812,10 @@ static int SupportsModernFullscreen(void) {
 	return [winHandle respondsToSelector:@selector(toggleFullScreen:)];
 }
 
+#if defined MAC_OS_X_VERSION_10_14 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_14
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 static NSOpenGLPixelFormat* MakePixelFormat(cc_bool fullscreen) {
 	// TODO: Is there a penalty for fullscreen contexts in 10.7 and later?
@@ -999,7 +1001,9 @@ cc_result Window_ExitFullscreen(void) {
 	return 0;
 }
 
+#if defined MAC_OS_X_VERSION_10_14 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_14
 #pragma clang diagnostic pop
+#endif
 
 #endif
 #endif

--- a/src/Window_cocoa.m
+++ b/src/Window_cocoa.m
@@ -261,7 +261,11 @@ static void RefreshWindowBounds(void) {
 - (void)keyDown:(NSEvent *)event { }
 @end
 
+#if defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
 @interface CCWindowDelegate : NSObject <NSWindowDelegate> { }
+#else
+@interface CCWindowDelegate : NSObject { }
+#endif
 @end
 @implementation CCWindowDelegate
 - (void)windowDidResize:(NSNotification *)notification {

--- a/src/Window_cocoa.m
+++ b/src/Window_cocoa.m
@@ -27,6 +27,7 @@ static cc_bool scroll_debugging;
 	#define DIALOG_OK      NSModalResponseOK
 	
 	#define PASTEBOARD_STRING_TYPE NSPasteboardTypeString
+	#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #else
 	#define WIN_MASK (NSTitledWindowMask | NSClosableWindowMask | NSResizableWindowMask | NSMiniaturizableWindowMask)
 	#define ANY_EVENT_MASK NSAnyEventMask
@@ -260,7 +261,7 @@ static void RefreshWindowBounds(void) {
 - (void)keyDown:(NSEvent *)event { }
 @end
 
-@interface CCWindowDelegate : NSObject { }
+@interface CCWindowDelegate : NSObject <NSWindowDelegate> { }
 @end
 @implementation CCWindowDelegate
 - (void)windowDidResize:(NSNotification *)notification {
@@ -494,7 +495,7 @@ static void ProcessKeyChars(id ev) {
 	len   = String_Length(src);
 
 	while (len > 0) {
-		i = Convert_Utf8ToCodepoint(&cp, src, len);
+		i = Convert_Utf8ToCodepoint(&cp, (const cc_uint8*)src, len);
 		if (!i) break;
 
 		Event_RaiseInt(&InputEvents.Press, cp);
@@ -630,8 +631,14 @@ void ShowDialogCore(const char* title, const char* msg) {
 	alert = [NSAlert alloc];
 	alert = [alert init];
 	
+#if defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+	[alert setMessageText: (__bridge NSString*)titleCF];
+	[alert setInformativeText: (__bridge NSString*)msgCF];
+#else
 	[alert setMessageText: titleCF];
 	[alert setInformativeText: msgCF];
+#endif
+
 	[alert addButtonWithTitle: @"OK"];
 	
 	[alert runModal];
@@ -647,7 +654,14 @@ static NSMutableArray* GetOpenSaveFilters(const char* const* filters) {
     {
         NSString* filter = [NSString stringWithUTF8String:filters[i]];
         filter = [filter substringFromIndex:1];
-        [types addObject:filter];
+#if defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+		UTType* uttype = [UTType typeWithFilenameExtension:filter];
+		if (uttype) {
+			[types addObject:uttype];
+		}
+#else
+		[types addObject:filter];
+#endif 
     }
     return types;
 }
@@ -673,7 +687,11 @@ cc_result Window_SaveFileDialog(const struct SaveFileDialogArgs* args) {
 	// TODO: Use args->defaultName, but only macOS 10.6
 
     NSMutableArray* types = GetOpenSaveFilters(args->filters);
-    [dlg setAllowedFileTypes:types];
+#if defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+	[dlg setAllowedContentTypes:types];
+#else
+	[dlg setAllowedFileTypes:types];
+#endif
 	if ([dlg runModal] != DIALOG_OK) return 0;
 
 	NSURL* file = [dlg URL];
@@ -686,7 +704,12 @@ cc_result Window_OpenFileDialog(const struct OpenFileDialogArgs* args) {
     
     NSMutableArray* types = GetOpenSaveFilters(args->filters);
     [dlg setCanChooseFiles: YES];
-    if ([dlg runModalForTypes:types] != DIALOG_OK) return 0;
+#if defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+	[dlg setAllowedContentTypes:types];
+	if ([dlg runModal] != DIALOG_OK) return 0;
+#else
+	if ([dlg runModalForTypes:types] != DIALOG_OK) return 0;
+#endif
     // unfortunately below code doesn't work when linked against SDK < 10.6
     //   https://developer.apple.com/documentation/appkit/nssavepanel/1534419-allowedfiletypes
     // [dlg setAllowedFileTypes:types];
@@ -727,7 +750,11 @@ static void DoDrawFramebuffer(NSRect dirty) {
 	// TODO: Find a better way of doing this in cocoa..
 	if (!fb_bmp.scan0) return;
 	nsContext = [NSGraphicsContext currentContext];
+#if defined MAC_OS_X_VERSION_10_12 && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+	context   = [nsContext CGContext];
+#else
 	context   = [nsContext graphicsPort];
+#endif
 
 	// TODO: Only update changed bit..
 	rect.origin.x = 0; rect.origin.y = 0;
@@ -784,6 +811,9 @@ static NSOpenGLContext* ctxHandle;
 static int SupportsModernFullscreen(void) {
 	return [winHandle respondsToSelector:@selector(toggleFullScreen:)];
 }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 static NSOpenGLPixelFormat* MakePixelFormat(cc_bool fullscreen) {
 	// TODO: Is there a penalty for fullscreen contexts in 10.7 and later?
@@ -968,5 +998,8 @@ cc_result Window_ExitFullscreen(void) {
 	Event_RaiseVoid(&WindowEvents.Resized);
 	return 0;
 }
+
+#pragma clang diagnostic pop
+
 #endif
 #endif

--- a/src/freetype/ftmac.c
+++ b/src/freetype/ftmac.c
@@ -1,3 +1,4 @@
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 /***************************************************************************/
 /*                                                                         */
 /*  ftmac.c                                                                */


### PR DESCRIPTION
This project will not build on the current release of macOS (10.15). This is because it has many warnings about deprecated code, and since the compiler uses `-Werror` to convert all warnings to errors, it will convert these deprecations to errors.

A simple fix is to remove this flag and build it, nothing seems to go wrong, but this is not a good answer. This pull request has changed parts of the code to support the newer macOS systems. Since I am not familiar with older macOS, nor do I have a machine that runs it, I cannot test it, and do not know what libraries are included in the older OS's. So I have created ifdefs around the problem parts. This will use the old code for older systems, but if it is deprecated, it will use the newer code.

Some caveats to this approach:
- `ftmac.c` is part of a third party library, and I did not feel right modifying it. So I just had the compiler ignore the entire file.
  - This code is also above me, and I couldn't fix it in a weekend project. So this can be left for someone else
- `Window_cocoa.m` has had many parts ifdef'd, but some required more work
- I had to add a framework for later versions of macOS
- I'm not sure if apple changed the required parameters of functions, but some errors were from improper casting
  - I added a cast to these systems, if this causes an error on older systems, we can easily add another ifdef for those
- The final problem is OpenGL
  - macOS has deprecated OpenGL in favor of Metal (which could be causing the high CPU/GPU usage in some cases)
  - This would require a bit of refactoring, that did not feel right doing in this issue
  - so I left this code alone and told the compiler to ignore these errors.

Any questions or comments let me know. I am unable to test on older macOS, but I do not change the original code too much. This project is very interesting, and I was sad when it wouldn't compile in a single step.