### PR TITLE
Replace FANCY_AO constant with user-configurable value

### DIFF
--- a/src/Builder.c
+++ b/src/Builder.c
@@ -1322,9 +1322,9 @@ static PackedCol Modern_GetColorX(PackedCol orig, int x, int y, int z, int oY, i
 	cc_bool zOccluded =  Modern_IsOccluded(x, y     , z + oZ);
 	cc_bool xzOccluded = Modern_IsOccluded(x, y + oY, z + oZ);
 
-	PackedCol CoX = xOccluded ? PackedCol_Scale(orig, FANCY_AO) : Lighting.Color_XSide_Fast(x, y + oY, z     );
-	PackedCol CoZ = zOccluded ? PackedCol_Scale(orig, FANCY_AO) : Lighting.Color_XSide_Fast(x, y     , z + oZ);
-	PackedCol CoXoZ = (xzOccluded || (xOccluded && zOccluded)) ? PackedCol_Scale(orig, FANCY_AO) : Lighting.Color_XSide_Fast(x, y + oY, z + oZ);
+	PackedCol CoX = xOccluded ? PackedCol_Scale(orig, Lighting_AOStrength) : Lighting.Color_XSide_Fast(x, y + oY, z     );
+	PackedCol CoZ = zOccluded ? PackedCol_Scale(orig, Lighting_AOStrength) : Lighting.Color_XSide_Fast(x, y     , z + oZ);
+	PackedCol CoXoZ = (xzOccluded || (xOccluded && zOccluded)) ? PackedCol_Scale(orig, Lighting_AOStrength) : Lighting.Color_XSide_Fast(x, y + oY, z + oZ);
 
 	PackedCol ab = AVERAGE(CoX, CoZ);
 	PackedCol cd = AVERAGE(CoXoZ, orig);
@@ -1401,9 +1401,9 @@ static PackedCol Modern_GetColorZ(PackedCol orig, int x, int y, int z, int oX, i
 	cc_bool zOccluded  = Modern_IsOccluded(x,      y + oY, z);
 	cc_bool xzOccluded = Modern_IsOccluded(x + oX, y + oY, z);
 
-	PackedCol CoX   =                                xOccluded ? PackedCol_Scale(orig, FANCY_AO) : Lighting.Color_ZSide_Fast(x + oX, y     , z);
-	PackedCol CoZ   =                                zOccluded ? PackedCol_Scale(orig, FANCY_AO) : Lighting.Color_ZSide_Fast(x     , y + oY, z);
-	PackedCol CoXoZ = (xzOccluded || (xOccluded && zOccluded)) ? PackedCol_Scale(orig, FANCY_AO) : Lighting.Color_ZSide_Fast(x + oX, y + oY, z);
+	PackedCol CoX   =                                xOccluded ? PackedCol_Scale(orig, Lighting_AOStrength) : Lighting.Color_ZSide_Fast(x + oX, y     , z);
+	PackedCol CoZ   =                                zOccluded ? PackedCol_Scale(orig, Lighting_AOStrength) : Lighting.Color_ZSide_Fast(x     , y + oY, z);
+	PackedCol CoXoZ = (xzOccluded || (xOccluded && zOccluded)) ? PackedCol_Scale(orig, Lighting_AOStrength) : Lighting.Color_ZSide_Fast(x + oX, y + oY, z);
 
 	PackedCol ab = AVERAGE(CoX, CoZ);
 	PackedCol cd = AVERAGE(CoXoZ, orig);
@@ -1480,9 +1480,9 @@ static PackedCol Modern_GetColorYMin(PackedCol orig, int x, int y, int z, int oX
 	cc_bool zOccluded  = Modern_IsOccluded(x,      y, z + oZ);
 	cc_bool xzOccluded = Modern_IsOccluded(x + oX, y, z + oZ);
 
-	PackedCol CoX   =                                xOccluded ? PackedCol_Scale(orig, FANCY_AO) : Lighting.Color_YMin_Fast(x + oX, y, z     );
-	PackedCol CoZ   =                                zOccluded ? PackedCol_Scale(orig, FANCY_AO) : Lighting.Color_YMin_Fast(x     , y, z + oZ);
-	PackedCol CoXoZ = (xzOccluded || (xOccluded && zOccluded)) ? PackedCol_Scale(orig, FANCY_AO) : Lighting.Color_YMin_Fast(x + oX, y, z + oZ);
+	PackedCol CoX   =                                xOccluded ? PackedCol_Scale(orig, Lighting_AOStrength) : Lighting.Color_YMin_Fast(x + oX, y, z     );
+	PackedCol CoZ   =                                zOccluded ? PackedCol_Scale(orig, Lighting_AOStrength) : Lighting.Color_YMin_Fast(x     , y, z + oZ);
+	PackedCol CoXoZ = (xzOccluded || (xOccluded && zOccluded)) ? PackedCol_Scale(orig, Lighting_AOStrength) : Lighting.Color_YMin_Fast(x + oX, y, z + oZ);
 
 	PackedCol ab = AVERAGE(CoX, CoZ);
 	PackedCol cd = AVERAGE(CoXoZ, orig);
@@ -1526,9 +1526,9 @@ static PackedCol Modern_GetColorYMax(PackedCol orig, int x, int y, int z, int oX
 	cc_bool zOccluded  = Modern_IsOccluded(x,      y, z + oZ);
 	cc_bool xzOccluded = Modern_IsOccluded(x + oX, y, z + oZ);
 
-	PackedCol CoX   =                                xOccluded ? PackedCol_Scale(orig, FANCY_AO) : Lighting.Color(x + oX, y, z     );
-	PackedCol CoZ   =                                zOccluded ? PackedCol_Scale(orig, FANCY_AO) : Lighting.Color(x     , y, z + oZ);
-	PackedCol CoXoZ = (xzOccluded || (xOccluded && zOccluded)) ? PackedCol_Scale(orig, FANCY_AO) : Lighting.Color(x + oX, y, z + oZ);
+	PackedCol CoX   =                                xOccluded ? PackedCol_Scale(orig, Lighting_AOStrength) : Lighting.Color(x + oX, y, z     );
+	PackedCol CoZ   =                                zOccluded ? PackedCol_Scale(orig, Lighting_AOStrength) : Lighting.Color(x     , y, z + oZ);
+	PackedCol CoXoZ = (xzOccluded || (xOccluded && zOccluded)) ? PackedCol_Scale(orig, Lighting_AOStrength) : Lighting.Color(x + oX, y, z + oZ);
 
 	PackedCol ab = AVERAGE(CoX, CoZ);
 	PackedCol cd = AVERAGE(CoXoZ, orig);

--- a/src/Lighting.c
+++ b/src/Lighting.c
@@ -32,10 +32,6 @@ void Lighting_SetMode(cc_uint8 mode, cc_bool fromServer) {
 	Event_RaiseLightingMode(&WorldEvents.LightingModeChanged, oldMode, fromServer);
 }
 
-void Lighting_SetAOStrength(float strength) {
-	Lighting_AOStrength = strength;
-}
-
 
 /*########################################################################################################################*
 *----------------------------------------------------Classic lighting-----------------------------------------------------*

--- a/src/Lighting.c
+++ b/src/Lighting.c
@@ -19,6 +19,9 @@ cc_uint8 Lighting_Mode;
 cc_bool  Lighting_ModeLockedByServer;
 cc_bool  Lighting_ModeSetByServer;
 cc_uint8 Lighting_ModeUserCached;
+
+float    Lighting_AOStrength;
+
 struct _Lighting Lighting;
 #define Lighting_Pack(x, z) ((x) + World.Width * (z))
 
@@ -27,6 +30,10 @@ void Lighting_SetMode(cc_uint8 mode, cc_bool fromServer) {
 	Lighting_Mode    = mode;
 
 	Event_RaiseLightingMode(&WorldEvents.LightingModeChanged, oldMode, fromServer);
+}
+
+void Lighting_SetAOStrength(float strength) {
+	Lighting_AOStrength = strength;
 }
 
 
@@ -457,6 +464,8 @@ static void OnInit(void) {
 	Lighting_ModeLockedByServer = false;
 	Lighting_ModeSetByServer    = false;
 	Lighting_ModeUserCached = Lighting_Mode;
+
+	Lighting_AOStrength = Options_GetFloat(OPT_AO_STRENGTH, 0.0F, 1.0F, 0.5F);
 
 	FancyLighting_OnInit();
 	Lighting_ApplyActive();

--- a/src/Lighting.h
+++ b/src/Lighting.h
@@ -27,7 +27,6 @@ extern cc_uint8 Lighting_ModeUserCached;
 void Lighting_SetMode(cc_uint8 mode, cc_bool fromServer);
 
 extern float Lighting_AOStrength;
-void Lighting_SetAOStrength(float strength);
 
 
 /* How much ambient occlusion to apply in fancy lighting where 1.0f = none and 0.0f = maximum*/
@@ -78,8 +77,6 @@ CC_VAR extern struct _Lighting {
 	PackedCol (*Color_YMin_Fast)(int x, int y, int z);
 	PackedCol (*Color_XSide_Fast)(int x, int y, int z);
 	PackedCol (*Color_ZSide_Fast)(int x, int y, int z);
-
-	float AOStrength;
 } Lighting;
 
 void FancyLighting_SetActive(void);

--- a/src/Lighting.h
+++ b/src/Lighting.h
@@ -26,9 +26,15 @@ extern cc_bool Lighting_ModeSetByServer;
 extern cc_uint8 Lighting_ModeUserCached;
 void Lighting_SetMode(cc_uint8 mode, cc_bool fromServer);
 
+extern float Lighting_AOStrength;
+void Lighting_SetAOStrength(float strength);
+
 
 /* How much ambient occlusion to apply in fancy lighting where 1.0f = none and 0.0f = maximum*/
-#define FANCY_AO 0.5F
+/* bunabyte: deprecated in favour of user-configurable value */
+#if 0
+	#define FANCY_AO 0.5F
+#endif
 /* How many unique "levels" of light there are when fancy lighting is used. */
 #define FANCY_LIGHTING_LEVELS 16
 #define FANCY_LIGHTING_MAX_LEVEL (FANCY_LIGHTING_LEVELS - 1)
@@ -72,6 +78,8 @@ CC_VAR extern struct _Lighting {
 	PackedCol (*Color_YMin_Fast)(int x, int y, int z);
 	PackedCol (*Color_XSide_Fast)(int x, int y, int z);
 	PackedCol (*Color_ZSide_Fast)(int x, int y, int z);
+
+	float AOStrength;
 } Lighting;
 
 void FancyLighting_SetActive(void);

--- a/src/MenuOptions.c
+++ b/src/MenuOptions.c
@@ -714,6 +714,17 @@ void EnvSettingsScreen_Show(void) {
 /*########################################################################################################################*
 *--------------------------------------------------GraphicsOptionsScreen--------------------------------------------------*
 *#########################################################################################################################*/
+
+/* bunabyte: Similar to other SetScale methods, but "inverts" the result by subtracting it from 1.0 */
+static void GraphicsOptionsScreen_SetScaleInverse(const cc_string* v, float* target, const char* optKey) {
+	float fv = Menu_Float(v);
+	float fvInverse = 1.0F - fv;
+
+	*target = fvInverse;
+	Options_Set(optKey, v);
+	Gui_LayoutAll();
+}
+
 static void GrO_CheckLightingModeAllowed(struct MenuOptionsScreen* s) {
 	Widget_SetDisabled(s->widgets[3], Lighting_ModeLockedByServer);
 }
@@ -743,6 +754,14 @@ static void GrO_SetLighting(int v) {
 
 	Lighting_ModeSetByServer = false;
 	Lighting_SetMode(v, false);
+}
+
+static void GrO_GetAOStrength(cc_string* v) { String_AppendFloat(v, 1.0F - Lighting_AOStrength, 2); }
+static void GrO_SetAOStrength(const cc_string* v) { 
+	GraphicsOptionsScreen_SetScaleInverse(v, &Lighting_AOStrength, OPT_AO_STRENGTH); 
+
+	Builder_ApplyActive();
+	MapRenderer_Refresh();
 }
 
 static int  GrO_GetNames(void) { return Entities.NamesMode; }
@@ -789,6 +808,11 @@ static void GraphicsOptionsScreen_InitWidgets(struct MenuOptionsScreen* s) {
 			"&eFancy: &fBright blocks cast a much wider range of light\n" \
 			"    May heavily reduce performance.\n" \
 			"&cNote: &eIn multiplayer, this option may be changed or locked by the server.");
+		MenuOptionsScreen_AddNum(s, "AO strength",
+			0.0f, 1.0f, 0.5f,
+			GrO_GetAOStrength,   GrO_SetAOStrength,
+			"Controls the darkness of corner shading when Fancy lighting is enabled.\n" \
+			"1 is full intensity, 0 is barely visible.");
 			
 		MenuOptionsScreen_AddEnum(s, "Names",   NameMode_Names,   NAME_MODE_COUNT,
 			GrO_GetNames,      GrO_SetNames,
@@ -800,7 +824,7 @@ static void GraphicsOptionsScreen_InitWidgets(struct MenuOptionsScreen* s) {
 		MenuOptionsScreen_AddEnum(s, "Shadows", ShadowMode_Names, SHADOW_MODE_COUNT,
 			GrO_GetShadows,    GrO_SetShadows,
 			"&eNone: &fNo entity shadows are drawn.\n" \
-			"&eSnapToBlock: &fA square shadow is shown on block you are directly above.\n" \
+			"&eSnapToBlock: &fA square shadow is shown on the block you are directly above.\n" \
 			"&eCircle: &fA circular shadow is shown across the blocks you are above.\n" \
 			"&eCircleAll: &fA circular shadow is shown underneath all entities.");
 

--- a/src/Options.h
+++ b/src/Options.h
@@ -26,6 +26,7 @@ Copyright 2014-2025 ClassiCube | Licensed under BSD-3
 #define OPT_RENDER_TYPE "normal"
 #define OPT_SMOOTH_LIGHTING "gfx-smoothlighting"
 #define OPT_LIGHTING_MODE "gfx-lightingmode"
+#define OPT_AO_STRENGTH "gfx-aostrength"
 #define OPT_MIPMAPS "gfx-mipmaps"
 #define OPT_CHAT_LOGGING "chat-logging"
 #define OPT_WINDOW_WIDTH "window-width"


### PR DESCRIPTION
This is a fairly simple change. Some users may not like the look of 50%-visible ambient occlusion. and will wish to change it to align more closely with what they remember from older versions of Minecraft. It might be somewhat helpful to move this option into the "Nostalgia" screen, since its main purpose is to more closely approximate the behaviour of old versions of Minecraft, and so it may be easier for users to find it there, maybe even merged with a more obvious setting. I think this is good enough for now though.