### PR TITLE
NDS: Small improvements

### DIFF
--- a/src/Graphics_NDS.c
+++ b/src/Graphics_NDS.c
@@ -377,11 +377,8 @@ GfxResourceID Gfx_AllocTexture(struct Bitmap* bmp, int rowWidth, cc_uint8 flags,
 	u16* tmp_u16[128]; // 256 bytes
 	char* tmp = (char*)tmp_u16;
 
-	u32 banks = VRAM_CR;
-	vramSetBankA(VRAM_A_LCD);
-	vramSetBankB(VRAM_B_LCD);
-	vramSetBankC(VRAM_C_LCD);
-	vramSetBankD(VRAM_D_LCD);
+	u32 banks = vramSetPrimaryBanks(VRAM_A_LCD, VRAM_B_LCD, VRAM_C_LCD, VRAM_D_LCD);
+
 	int stride;
 
 	if (tex_fmt == GL_RGB4) {
@@ -448,7 +445,7 @@ GfxResourceID Gfx_AllocTexture(struct Bitmap* bmp, int rowWidth, cc_uint8 flags,
 		}
 	}
 
-	VRAM_CR = banks;
+	vramRestorePrimaryBanks(banks);
 
 	int sSize  = (Math_ilog2(tex->width)  - 3) << 20;
 	int tSize  = (Math_ilog2(tex->height) - 3) << 23;

--- a/src/Graphics_NDS.c
+++ b/src/Graphics_NDS.c
@@ -448,8 +448,6 @@ GfxResourceID Gfx_AllocTexture(struct Bitmap* bmp, int rowWidth, cc_uint8 flags,
 		}
 	}
 
-	// Ensure anything in data cache is flushed to VRAM
-	DC_FlushRange((u8*)VRAM_A + offset, tex_size);
 	VRAM_CR = banks;
 
 	int sSize  = (Math_ilog2(tex->width)  - 3) << 20;


### PR DESCRIPTION
1. Use libnds helpers to set and restore VRAM banks

2. Stop flushing VRAM after copying to it

The VRAM memory area isn't cacheable, so there is no need to use `DC_FlushRange()`, and we can improve performance a bit by removing the call.

This function would only be required if we were using DMA to copy the data to VRAM. In that case, the source in main RAM would have to be flushed before doing the DMA copy. However, `CopyHWords()` is a plain CPU copy, so this isn't needed at all.

The following two articles are a nice introduction to cache handling on the NDS:

https://web.archive.org/web/20210622053504/https://www.coranac.com/2009/05/dma-vs-arm9-fight/

https://web.archive.org/web/20210622053550/https://www.coranac.com/2010/03/dma-vs-arm9-round-2/