### PR TITLE
SDL3: Fix only 1 filter type showing on save dialog

### DIFF
--- a/misc/flatpak/net.classicube.flatpak.client.SDL3.json
+++ b/misc/flatpak/net.classicube.flatpak.client.SDL3.json
@@ -1,7 +1,7 @@
 {
     "id": "net.classicube.flatpak.client",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "command": "ClassiCubeLauncher",
     "finish-args": [

--- a/src/Window_SDL3.c
+++ b/src/Window_SDL3.c
@@ -426,7 +426,7 @@ cc_result Window_SaveFileDialog(const struct SaveFileDialogArgs* args) {
 	
 	dlgCallback  = args->Callback;
 	save_filters = filters;
-	SDL_ShowSaveFileDialog(DialogCallback, NULL, win_handle, filters, 1, defName);
+	SDL_ShowSaveFileDialog(DialogCallback, NULL, win_handle, filters, i, defName);
 	return 0;
 }
 


### PR DESCRIPTION
| Before    | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/c10ff58e-1d8c-4ce9-97f8-41c655c7df5d) | ![After](https://github.com/user-attachments/assets/fed9d1a2-9ee0-4947-9bec-64cba95ae876)|

Also upgraded the flatpak runtime to version 48.