### PR TITLE
Fixed type error stopping compilation

### DIFF
--- a/src/Graphics_GL1.c
+++ b/src/Graphics_GL1.c
@@ -105,7 +105,7 @@ void Gfx_Create(void) {
 #ifndef CC_BUILD_GL11
 GfxResourceID Gfx_CreateIb2(int count, Gfx_FillIBFunc fillFunc, void* obj) {
 #ifndef GL_INDICES
-	cc_uint16* gl_indices[GFX_MAX_INDICES];
+	cc_uint16 gl_indices[GFX_MAX_INDICES];
 #endif
 	GfxResourceID id = NULL;
 	cc_uint32 size   = count * sizeof(cc_uint16);


### PR DESCRIPTION

![2025-05-24-185451_1692x186_scrot](https://github.com/user-attachments/assets/6c4b5da4-d8fc-4be9-b4d0-25a78c5775bf)

fixed issue where gl_indices was defined as a cc_uint16** despite "fillFunc" wanting a cc_uint16*