### PR TITLE
SDL: Set GL attributes before creating the window

### DIFF
--- a/src/Window_SDL2.c
+++ b/src/Window_SDL2.c
@@ -38,6 +38,8 @@ typedef struct _WINDATA {
 #endif
 
 
+static void SetGLAttributes();
+
 static void RefreshWindowBounds(void) {
 	SDL_GetWindowSize(win_handle, &Window_Main.Width, &Window_Main.Height);
 }
@@ -99,7 +101,10 @@ static void DoCreateWindow(int width, int height, int flags) {
 
 void Window_Create2D(int width, int height) { DoCreateWindow(width, height, 0); }
 #if CC_GFX_BACKEND_IS_GL()
-void Window_Create3D(int width, int height) { DoCreateWindow(width, height, SDL_WINDOW_OPENGL); }
+void Window_Create3D(int width, int height) {
+	SetGLAttributes();
+	DoCreateWindow(width, height, SDL_WINDOW_OPENGL);
+}
 #else
 void Window_Create3D(int width, int height) { DoCreateWindow(width, height, 0); }
 #endif
@@ -537,7 +542,7 @@ void Gamepads_Process(float delta) {
 #if CC_GFX_BACKEND_IS_GL()
 static SDL_GLContext win_ctx;
 
-void GLContext_Create(void) {
+void SetGLAttributes(void) {
 	struct GraphicsMode mode;
 	InitGraphicsMode(&mode);
 	SDL_GL_SetAttribute(SDL_GL_RED_SIZE,   mode.R);
@@ -553,7 +558,9 @@ void GLContext_Create(void) {
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 #endif
+}
 
+void GLContext_Create(void) {
 	win_ctx = SDL_GL_CreateContext(win_handle);
 	if (!win_ctx) Window_SDLFail("creating OpenGL context");
 }

--- a/src/Window_SDL3.c
+++ b/src/Window_SDL3.c
@@ -11,6 +11,8 @@
 static SDL_Window* win_handle;
 static Uint32 dlg_event;
 
+static void SetGLAttributes();
+
 static void RefreshWindowBounds(void) {
 	SDL_GetWindowSize(win_handle, &Window_Main.Width, &Window_Main.Height);
 }
@@ -84,7 +86,10 @@ static void DoCreateWindow(int width, int height, int flags) {
 
 void Window_Create2D(int width, int height) { DoCreateWindow(width, height, 0); }
 #if CC_GFX_BACKEND_IS_GL()
-void Window_Create3D(int width, int height) { DoCreateWindow(width, height, SDL_WINDOW_OPENGL); }
+void Window_Create3D(int width, int height) {
+	SetGLAttributes();
+	DoCreateWindow(width, height, SDL_WINDOW_OPENGL);
+}
 #else
 void Window_Create3D(int width, int height) { DoCreateWindow(width, height, 0); }
 #endif
@@ -567,7 +572,7 @@ void Gamepads_Process(float delta) {
 #if CC_GFX_BACKEND_IS_GL()
 static SDL_GLContext win_ctx;
 
-void GLContext_Create(void) {
+void SetGLAttributes(void) {
 	struct GraphicsMode mode;
 	InitGraphicsMode(&mode);
 	SDL_GL_SetAttribute(SDL_GL_RED_SIZE,   mode.R);
@@ -583,7 +588,9 @@ void GLContext_Create(void) {
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 #endif
+}
 
+void GLContext_Create(void) {
 	win_ctx = SDL_GL_CreateContext(win_handle);
 	if (!win_ctx) Window_SDLFail("creating OpenGL context");
 }


### PR DESCRIPTION
The documentation for [`SDL_GL_SetAttribute`](https://wiki.libsdl.org/SDL3/SDL_GL_SetAttribute) states:

> The requested attributes should be set before creating an OpenGL window.

This is because on some platforms the attributes are needed at window creation time, before the context is created. For example, on EGL-based platforms (like Wayland), some attributes such as bit depths are part of the surface, which is created alongside the window, and not the context.