### PR TITLE
Fix instructions for MSVC command-line build

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ If you get a `The Windows SDK version 5.1 was not found` compilation error, [see
 ##### Using Visual Studio (command line)
 1. Use 'Developer Tools for Visual Studio' from Start Menu
 2. Navigate to the directory with ClassiCube's source code
-3. Run `cl.exe *.c /link user32.lib gdi32.lib winmm.lib dbghelp.lib shell32.lib comdlg32.lib /out:ClassiCube.exe`
+3. Run `cl.exe src\*.c third_party\bearssl\*.c /link user32.lib gdi32.lib winmm.lib dbghelp.lib shell32.lib comdlg32.lib /out:ClassiCube.exe`
 
 ##### Using MinGW-w64
 Assuming that you used the installer from https://sourceforge.net/projects/mingw-w64/ :


### PR DESCRIPTION
The MSVC command-line instructions in the README currently do not work. I get this build error:

```
SSL.obj : error LNK2019: unresolved external symbol _br_ssl_engine_set_buffer referenced in function _SSL_Init
SSL.obj : error LNK2019: unresolved external symbol _br_ssl_engine_inject_entropy referenced in function _InjectEntropy
SSL.obj : error LNK2019: unresolved external symbol _br_ssl_engine_current_state referenced in function _SSL_Read
SSL.obj : error LNK2019: unresolved external symbol _br_ssl_client_init_full referenced in function _SSL_Init
SSL.obj : error LNK2019: unresolved external symbol _br_ssl_client_reset referenced in function _SSL_Init
SSL.obj : error LNK2019: unresolved external symbol _br_sslio_init referenced in function _SSL_Init
SSL.obj : error LNK2019: unresolved external symbol _br_sslio_read referenced in function _SSL_Read
SSL.obj : error LNK2019: unresolved external symbol _br_sslio_write_all referenced in function _SSL_WriteAll
SSL.obj : error LNK2019: unresolved external symbol _br_sslio_flush referenced in function _SSL_Read
SSL.obj : error LNK2019: unresolved external symbol _br_sslio_close referenced in function _SSL_Free
SSL.obj : error LNK2019: unresolved external symbol _br_x509_minimal_vtable referenced in function _br_ssl_engine_last_error
```

Adding BearSSL to the compilation command fixes it:

```
cl.exe src\*.c third_party\bearssl\*.c /link user32.lib gdi32.lib winmm.lib dbghelp.lib shell32.lib comdlg32.lib /out:ClassiCube.exe
```