### PR TITLE
Support Game Mode for macOS

### DIFF
--- a/misc/macOS/info.plist
+++ b/misc/macOS/info.plist
@@ -16,5 +16,7 @@
 	<string>APPL</string>
 	<key>CFBundleDisplayName</key>
 	<string>ClassiCube</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
 </dict>
 </plist>


### PR DESCRIPTION
Allows the [Game Mode](https://support.apple.com/en-us/105118) feature, introduced in macOS 14 (Apple silicon only), to be enabled when playing ClassiCube and the game is on full screen by setting the application category type to "Games" in the Info.plist file. This supposedly improves performance by minimizing background tasks.