### PR TITLE
hpux 11iv3 fixes, use mesa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILD_DIRS	= $(BUILD_DIR) $(BUILD_DIR)/src
 # Configurable flags and names
 ##############################
 # Flags passed to the C compiler
-CFLAGS  = -pipe -fno-math-errno -Werror -Wno-error=missing-braces -Wno-error=strict-aliasing
+CFLAGS  = -pipe -fno-math-errno
 # Flags passed to the linker
 LDFLAGS = -g -rdynamic
 # Name of the main executable
@@ -88,8 +88,9 @@ endif
 
 ifeq ($(PLAT),hp-ux)
 	CC      = gcc
+	CFLAGS  += -std=c99 -D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=600 -D_DEFAULT_SOURCE -D_BSD_SOURCE
 	LDFLAGS =
-	LIBS    = -lm -lX11 -lXi -lXext -L/opt/graphics/OpenGL/lib -lGL -lpthread
+	LIBS    = -lm -lX11 -lXi -lXext -L/usr/local/lib/hpux32 -lGL -lpthread
 	BUILD_DIR = build/hpux
 endif
 

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ And also runs on:
 * Haiku - needs <code>openal</code> package (if you have a GitHub account, can [download from here](https://github.com/ClassiCube/ClassiCube/actions/workflows/build_haiku.yml))
 * BeOS - untested on actual hardware
 * IRIX - needs <code>openal</code> packages
+* HP-UX - needs Mesa package, tried building with HP OpenGL and `-DCC_BUILD_GL11` still not working
 * SerenityOS - needs <code>SDL2</code>
 * Classic Mac OS (System 7 and later)
 * Dreamcast - unfinished, but usable (can [download from here](https://www.classicube.net/download/dreamcast))

--- a/src/Logger.c
+++ b/src/Logger.c
@@ -280,6 +280,12 @@ static void DumpFrame(cc_string* trace, void* addr) {
 	cc_uintptr addr_ = (cc_uintptr)addr;
 	String_Format1(trace, "%x", &addr_);
 }
+#elif defined CC_BUILD_HPUX
+/* HP-UX doesn't expose a nice interface for dladdr */
+static void DumpFrame(cc_string* trace, void* addr) {
+	cc_uintptr addr_ = (cc_uintptr)addr;
+	String_Format1(trace, "%x", &addr_);
+}
 #elif defined CC_BUILD_POSIX && !defined CC_BUILD_OS2
 /* need to define __USE_GNU for dladdr */
 #ifndef __USE_GNU
@@ -454,6 +460,11 @@ void Logger_Backtrace(cc_string* trace, void* ctx) {
 void Logger_Backtrace(cc_string* trace, void* ctx) {
 	String_AppendConst(trace, "-- backtrace unimplemented --");
 	/* There is no dladdr on Symbian */
+}
+#elif defined CC_BUILD_HPUX
+/* HP-UX doesn't have unwind support */
+void Logger_Backtrace(cc_string* trace, void* ctx) {
+	String_AppendConst(trace, "-- backtrace unimplemented --");
 }
 #elif defined CC_BUILD_POSIX
 /* musl etc - rely on unwind from GCC instead */

--- a/src/Platform_Posix.c
+++ b/src/Platform_Posix.c
@@ -800,9 +800,16 @@ cc_result Socket_Create(cc_socket* s, cc_sockaddr* addr, cc_bool nonblocking) {
 	if (*s == -1) return errno;
 
 	if (nonblocking) {
+#ifdef CC_BUILD_HPUX
+		int flags = fcntl(*s, F_GETFL, 0);
+		if (flags == -1) return errno;
+		int err = fcntl(*s, F_SETFL, flags | O_NONBLOCK);
+		if (err == -1) return errno;
+#else
 		int blocking_raw = -1; /* non-blocking mode */
 		int err = ioctl(*s, FIONBIO, &blocking_raw);
 		if (err == -1) return errno;
+#endif
 	}
 	return 0;
 }


### PR DESCRIPTION
fixes that make it build on hpux 11i v3

unfortunately unable to use HP OpenGL so far so changed to mesa, it builds and works with sw rendering

also tested on 11iv1 with 32 and 64bit flavors
