### PR TITLE
Add new fixed-point software renderer for FPU-less devices

### DIFF
--- a/src/Core.h
+++ b/src/Core.h
@@ -147,6 +147,7 @@ typedef cc_uint8  cc_bool;
 #define CC_GFX_BACKEND_VULKAN    6
 #define CC_GFX_BACKEND_GL11      7
 #define CC_GFX_BACKEND_SOFTMIN   8
+#define CC_GFX_BACKEND_SOFTFP   9
 
 #define CC_SSL_BACKEND_NONE      1
 #define CC_SSL_BACKEND_BEARSSL   2

--- a/src/Graphics_SoftFP.c
+++ b/src/Graphics_SoftFP.c
@@ -1,0 +1,1146 @@
+#include "Core.h"
+#if CC_GFX_BACKEND == CC_GFX_BACKEND_SOFTFP
+#include "_GraphicsBase.h"
+#include "Errors.h"
+#include "Window.h"
+#include <limits.h>
+#include <stdint.h>
+
+// 16.16 fixed point
+#define FP_SHIFT 16
+#define FP_ONE (1 << FP_SHIFT)
+#define FP_HALF (FP_ONE >> 1)
+#define FP_MASK ((1 << FP_SHIFT) - 1)
+
+#define ABS(x) ((x) < 0 ? -(x) : (x))
+
+#define FloatToFixed(x) ((int)((x) * FP_ONE))
+#define FixedToFloat(x) ((float)(x) / FP_ONE)
+#define FixedToInt(x) ((x) >> FP_SHIFT)
+#define IntToFixed(x) ((x) << FP_SHIFT)
+
+#define FixedMul(a, b) (((int64_t)(a) * (b)) >> FP_SHIFT)
+
+#define FixedDiv(a, b) (((int64_t)(a) << FP_SHIFT) / (b))
+
+static int FixedReciprocal(int x) {
+    if (x == 0) return 0;
+    int64_t res = ((int64_t)FP_ONE << FP_SHIFT) / (int64_t)x; // (1<<32)/x -> fixed reciprocal
+    if (res > INT_MAX) return INT_MAX;
+    if (res < INT_MIN) return INT_MIN;
+    return (int)res;
+}
+
+static cc_bool faceCulling;
+static int fb_width, fb_height; 
+static struct Bitmap fb_bmp;
+static int vp_hwidth_fp, vp_hheight_fp;
+static int fb_maxX, fb_maxY;
+
+static BitmapCol* colorBuffer;
+static BitmapCol clearColor;
+static cc_bool colWrite = true;
+static int cb_stride;
+
+static int* depthBuffer;
+static cc_bool depthTest  = true;
+static cc_bool depthWrite = true;
+static int db_stride;
+
+static void* gfx_vertices;
+static GfxResourceID white_square;
+
+typedef struct FixedMatrix {
+    int m[4][4];
+} FixedMatrix;
+
+typedef struct VertexFixed {
+    int x, y, z, w;
+    int u, v;
+    PackedCol c;
+} VertexFixed;
+
+static int texOffsetX_fp, texOffsetY_fp; // Fixed point texture offsets
+static FixedMatrix _view_fp, _proj_fp, _mvp_fp;
+
+static void Gfx_RestoreState(void) {
+    InitDefaultResources();
+
+    struct Bitmap bmp;
+    BitmapCol pixels[1] = { BITMAPCOLOR_WHITE };
+    Bitmap_Init(bmp, 1, 1, pixels);
+    white_square = Gfx_CreateTexture(&bmp, 0, false);
+}
+
+static void Gfx_FreeState(void) {
+    FreeDefaultResources();
+    Gfx_DeleteTexture(&white_square);
+}
+
+void Gfx_Create(void) {
+    Gfx.MaxTexWidth  = 4096;
+    Gfx.MaxTexHeight = 4096;
+    Gfx.Created      = true;
+    Gfx.BackendType  = CC_GFX_BACKEND_SOFTGPU;
+    Gfx.Limitations  = GFX_LIMIT_MINIMAL;
+    
+    Gfx_RestoreState();
+}
+
+static void DestroyBuffers(void) {
+    Window_FreeFramebuffer(&fb_bmp);
+    Mem_Free(depthBuffer);
+    depthBuffer = NULL;
+}
+
+void Gfx_Free(void) { 
+    Gfx_FreeState();
+    DestroyBuffers();
+}
+
+typedef struct CCTexture {
+    int width, height;
+    BitmapCol pixels[];
+} CCTexture;
+
+static CCTexture* curTexture;
+static BitmapCol* curTexPixels;
+static int curTexWidth, curTexHeight;
+static int texWidthMask, texHeightMask;
+static int texSinglePixel;
+        
+void Gfx_BindTexture(GfxResourceID texId) {
+    if (!texId) texId = white_square;
+    CCTexture* tex = texId;
+
+    curTexture   = tex;
+    curTexPixels = tex->pixels;
+    curTexWidth  = tex->width;
+    curTexHeight = tex->height;
+
+    texWidthMask   = (1 << Math_ilog2(tex->width))  - 1;
+    texHeightMask  = (1 << Math_ilog2(tex->height)) - 1;
+
+    texSinglePixel = curTexWidth == 1;
+}
+        
+void Gfx_DeleteTexture(GfxResourceID* texId) {
+    GfxResourceID data = *texId;
+    if (data) Mem_Free(data);
+    *texId = NULL;
+}
+        
+GfxResourceID Gfx_AllocTexture(struct Bitmap* bmp, int rowWidth, cc_uint8 flags, cc_bool mipmaps) {
+    CCTexture* tex = (CCTexture*)Mem_Alloc(2 + bmp->width * bmp->height, 4, "Texture");
+
+    tex->width  = bmp->width;
+    tex->height = bmp->height;
+
+    CopyPixels(tex->pixels, bmp->width * BITMAPCOLOR_SIZE,
+               bmp->scan0,  rowWidth * BITMAPCOLOR_SIZE,
+               bmp->width,  bmp->height);
+    return tex;
+}
+
+void Gfx_UpdateTexture(GfxResourceID texId, int x, int y, struct Bitmap* part, int rowWidth, cc_bool mipmaps) {
+    CCTexture* tex = (CCTexture*)texId;
+    BitmapCol* dst = (tex->pixels + x) + y * tex->width;
+
+    CopyPixels(dst,         tex->width * BITMAPCOLOR_SIZE,
+               part->scan0, rowWidth   * BITMAPCOLOR_SIZE,
+               part->width, part->height);
+}
+
+void Gfx_EnableMipmaps(void)  { }
+void Gfx_DisableMipmaps(void) { }
+
+/*########################################################################################################################*
+*------------------------------------------------------State management---------------------------------------------------*
+*#########################################################################################################################*/
+void Gfx_SetFog(cc_bool enabled)    { }
+void Gfx_SetFogCol(PackedCol col)   { }
+void Gfx_SetFogDensity(float value) { }
+void Gfx_SetFogEnd(float value)     { }
+void Gfx_SetFogMode(FogFunc func)   { }
+
+void Gfx_SetFaceCulling(cc_bool enabled) {
+    faceCulling = enabled;
+}
+
+static void SetAlphaTest(cc_bool enabled) {
+}
+
+static void SetAlphaBlend(cc_bool enabled) {
+}
+
+void Gfx_SetAlphaArgBlend(cc_bool enabled) { }
+
+static void ClearColorBuffer(void) {
+    int i, x, y, size = fb_width * fb_height;
+
+    if (cb_stride == fb_width) {
+        //for (i = 0; i < size; i++) colorBuffer[i] = clearColor;
+        Mem_Set(colorBuffer, clearColor, sizeof(colorBuffer) * size);
+    } else {
+        for (y = 0; y < fb_height; y++) {
+            i = y * cb_stride;
+            for (x = 0; x < fb_width; x++) {
+                colorBuffer[i + x] = clearColor;
+            }
+        }
+    }
+}
+
+static void ClearDepthBuffer(void) {
+    int i, size = fb_width * fb_height;
+    int maxDepth = 0x7FFFFFFF; // max depth
+    for (i = 0; i < size; i++) depthBuffer[i] = maxDepth;
+}
+
+void Gfx_ClearBuffers(GfxBuffers buffers) {
+    if (buffers & GFX_BUFFER_COLOR) ClearColorBuffer();
+    if (buffers & GFX_BUFFER_DEPTH) ClearDepthBuffer();
+}
+
+void Gfx_ClearColor(PackedCol color) {
+    int R = PackedCol_R(color);
+    int G = PackedCol_G(color);
+    int B = PackedCol_B(color);
+    int A = PackedCol_A(color);
+
+    clearColor = BitmapCol_Make(R, G, B, A);
+}
+
+void Gfx_SetDepthTest(cc_bool enabled) {
+    depthTest = enabled;
+}
+
+void Gfx_SetDepthWrite(cc_bool enabled) {
+    depthWrite = enabled;
+}
+
+static void SetColorWrite(cc_bool r, cc_bool g, cc_bool b, cc_bool a) {
+    // TODO
+}
+
+void Gfx_DepthOnlyRendering(cc_bool depthOnly) {
+    colWrite = !depthOnly;
+}
+
+/*########################################################################################################################*
+*-------------------------------------------------------Index buffers-----------------------------------------------------*
+*#########################################################################################################################*/
+GfxResourceID Gfx_CreateIb2(int count, Gfx_FillIBFunc fillFunc, void* obj) {
+    return (void*)1;
+}
+
+void Gfx_BindIb(GfxResourceID ib) { }
+void Gfx_DeleteIb(GfxResourceID* ib) { }
+
+/*########################################################################################################################*
+*-------------------------------------------------------Vertex buffers----------------------------------------------------*
+*#########################################################################################################################*/
+static GfxResourceID Gfx_AllocStaticVb(VertexFormat fmt, int count) {
+    return Mem_TryAlloc(count, strideSizes[fmt]);
+}
+
+void Gfx_BindVb(GfxResourceID vb) { gfx_vertices = vb; }
+
+void Gfx_DeleteVb(GfxResourceID* vb) {
+    GfxResourceID data = *vb;
+    if (data) Mem_Free(data);
+    *vb = 0;
+}
+
+void* Gfx_LockVb(GfxResourceID vb, VertexFormat fmt, int count) {
+    return vb;
+}
+
+void Gfx_UnlockVb(GfxResourceID vb) { 
+    gfx_vertices = vb; 
+}
+
+static GfxResourceID Gfx_AllocDynamicVb(VertexFormat fmt, int maxVertices) {
+    return Mem_TryAlloc(maxVertices, strideSizes[fmt]);
+}
+
+void Gfx_BindDynamicVb(GfxResourceID vb) { Gfx_BindVb(vb); }
+
+void* Gfx_LockDynamicVb(GfxResourceID vb, VertexFormat fmt, int count) {
+    return vb; 
+}
+
+void Gfx_UnlockDynamicVb(GfxResourceID vb) { 
+    gfx_vertices = vb;
+}
+
+void Gfx_DeleteDynamicVb(GfxResourceID* vb) { Gfx_DeleteVb(vb); }
+
+/*########################################################################################################################*
+*---------------------------------------------------------Matrices--------------------------------------------------------*
+*#########################################################################################################################*/
+
+static void MatrixToFixed(FixedMatrix* dst, const struct Matrix* src) {
+    dst->m[0][0] = FloatToFixed(src->row1.x); dst->m[0][1] = FloatToFixed(src->row1.y);
+    dst->m[0][2] = FloatToFixed(src->row1.z); dst->m[0][3] = FloatToFixed(src->row1.w);
+    
+    dst->m[1][0] = FloatToFixed(src->row2.x); dst->m[1][1] = FloatToFixed(src->row2.y);
+    dst->m[1][2] = FloatToFixed(src->row2.z); dst->m[1][3] = FloatToFixed(src->row2.w);
+    
+    dst->m[2][0] = FloatToFixed(src->row3.x); dst->m[2][1] = FloatToFixed(src->row3.y);
+    dst->m[2][2] = FloatToFixed(src->row3.z); dst->m[2][3] = FloatToFixed(src->row3.w);
+    
+    dst->m[3][0] = FloatToFixed(src->row4.x); dst->m[3][1] = FloatToFixed(src->row4.y);
+    dst->m[3][2] = FloatToFixed(src->row4.z); dst->m[3][3] = FloatToFixed(src->row4.w);
+}
+
+static void MatrixMulFixed(FixedMatrix* dst, const FixedMatrix* a, const FixedMatrix* b) {
+    int i, j, k;
+    for (i = 0; i < 4; i++) {
+        for (j = 0; j < 4; j++) {
+            int64_t sum = 0;
+            for (k = 0; k < 4; k++) {
+                sum += (int64_t)a->m[i][k] * b->m[k][j];
+            }
+            dst->m[i][j] = (int)(sum >> FP_SHIFT);
+        }
+    }
+}
+
+void Gfx_LoadMatrix(MatrixType type, const struct Matrix* matrix) {
+    if (type == MATRIX_VIEW) {
+        MatrixToFixed(&_view_fp, matrix);
+    }
+    if (type == MATRIX_PROJ) {
+        MatrixToFixed(&_proj_fp, matrix);
+    }
+
+    MatrixMulFixed(&_mvp_fp, &_view_fp, &_proj_fp);
+}
+
+void Gfx_LoadMVP(const struct Matrix* view, const struct Matrix* proj, struct Matrix* mvp) {
+    MatrixToFixed(&_view_fp, view);
+    MatrixToFixed(&_proj_fp, proj);
+
+    MatrixMulFixed(&_mvp_fp, &_view_fp, &_proj_fp);
+    
+    Matrix_Mul(mvp, view, proj);
+}
+
+void Gfx_EnableTextureOffset(float x, float y) {
+    texOffsetX_fp = FloatToFixed(x);
+    texOffsetY_fp = FloatToFixed(y);
+}
+
+void Gfx_DisableTextureOffset(void) {
+    texOffsetX_fp = 0;
+    texOffsetY_fp = 0;
+}
+
+void Gfx_CalcOrthoMatrix(struct Matrix* matrix, float width, float height, float zNear, float zFar) {
+    *matrix = Matrix_Identity;
+
+    matrix->row1.x =  2.0f / width;
+    matrix->row2.y = -2.0f / height;
+    matrix->row3.z =  1.0f / (zNear - zFar);
+
+    matrix->row4.x = -1.0f;
+    matrix->row4.y =  1.0f;
+    matrix->row4.z = zNear / (zNear - zFar);
+}
+
+static float Cotangent(float x) { return Math_CosF(x) / Math_SinF(x); }
+
+void Gfx_CalcPerspectiveMatrix(struct Matrix* matrix, float fov, float aspect, float zFar) {
+    float zNear = 0.1f;
+
+    float c = Cotangent(0.5f * fov);
+    *matrix = Matrix_Identity;
+
+    matrix->row1.x =  c / aspect;
+    matrix->row2.y =  c;
+    matrix->row3.z = zFar / (zNear - zFar);
+    matrix->row3.w = -1.0f;
+    matrix->row4.z = (zNear * zFar) / (zNear - zFar);
+    matrix->row4.w =  0.0f;
+}
+
+/*########################################################################################################################*
+*---------------------------------------------------------Rendering-------------------------------------------------------*
+*#########################################################################################################################*/
+
+enum { PLANE_LEFT=0, PLANE_RIGHT, PLANE_BOTTOM, PLANE_TOP, PLANE_NEAR, PLANE_FAR };
+
+static int PlaneDistFixed(const VertexFixed* v, int plane) {
+    int64_t result;
+    switch (plane) {
+    case PLANE_LEFT:
+        result = (int64_t)v->x + v->w;
+        break;
+    case PLANE_RIGHT:
+        result = (int64_t)v->w - v->x;
+        break;
+    case PLANE_BOTTOM:
+        result = (int64_t)v->y + v->w;
+        break;
+    case PLANE_TOP:
+        result = (int64_t)v->w - v->y;
+        break;
+    case PLANE_NEAR:
+        result = v->z;
+        break;
+    case PLANE_FAR:
+        result = (int64_t)v->w - (v->z >> 2); //hacked
+        break;
+    default:
+        return 0;
+    }
+    
+    // Clamp to valid range
+    if (result > INT_MAX) return INT_MAX;
+    if (result < INT_MIN) return INT_MIN;
+    return (int)result;
+}
+
+static void LerpClipFixed(VertexFixed* out, const VertexFixed* a, const VertexFixed* b, int t) {
+    if (t < 0) t = 0;
+    if (t > FP_ONE) t = FP_ONE;
+    
+    int invt = FP_ONE - t;
+    
+    int64_t x_interp = ((int64_t)invt * a->x + (int64_t)t * b->x) >> FP_SHIFT;
+    int64_t y_interp = ((int64_t)invt * a->y + (int64_t)t * b->y) >> FP_SHIFT;
+    int64_t z_interp = ((int64_t)invt * a->z + (int64_t)t * b->z) >> FP_SHIFT;
+    int64_t w_interp = ((int64_t)invt * a->w + (int64_t)t * b->w) >> FP_SHIFT;
+    int64_t u_interp = ((int64_t)invt * a->u + (int64_t)t * b->u) >> FP_SHIFT;
+    int64_t v_interp = ((int64_t)invt * a->v + (int64_t)t * b->v) >> FP_SHIFT;
+    
+    // Clamp results
+    out->x = (x_interp > INT_MAX) ? INT_MAX : (x_interp < INT_MIN) ? INT_MIN : (int)x_interp;
+    out->y = (y_interp > INT_MAX) ? INT_MAX : (y_interp < INT_MIN) ? INT_MIN : (int)y_interp;
+    out->z = (z_interp > INT_MAX) ? INT_MAX : (z_interp < INT_MIN) ? INT_MIN : (int)z_interp;
+    out->w = (w_interp > INT_MAX) ? INT_MAX : (w_interp < INT_MIN) ? INT_MIN : (int)w_interp;
+    out->u = (u_interp > INT_MAX) ? INT_MAX : (u_interp < INT_MIN) ? INT_MIN : (int)u_interp;
+    out->v = (v_interp > INT_MAX) ? INT_MAX : (v_interp < INT_MIN) ? INT_MIN : (int)v_interp;
+    
+    out->c = (t < FP_HALF) ? a->c : b->c;
+}
+
+static int SafeFixedDiv(int numerator, int denominator) {
+    if (denominator == 0) return FP_HALF;
+    if (ABS(denominator) < 16) return FP_HALF; // Avoid extreme divisions
+    
+    int64_t result = ((int64_t)numerator << FP_SHIFT) / denominator;
+    
+    if (result > FP_ONE) return FP_ONE;
+    if (result < 0) return 0;
+    return (int)result;
+}
+
+static int ClipPolygonPlaneFixed(const VertexFixed* in, int inCount, VertexFixed* out, int plane) {
+    if (inCount == 0) return 0;
+    if (inCount > 15) inCount = 15; // Safety limit
+    
+    int outCount = 0;
+    
+    for (int i = 0; i < inCount; i++) {
+        const VertexFixed* cur  = &in[i];
+        const VertexFixed* next = &in[(i + 1) % inCount];
+        
+        int dCur  = PlaneDistFixed(cur, plane);
+        int dNext = PlaneDistFixed(next, plane);
+        cc_bool curIn  = dCur >= 0;
+        cc_bool nextIn = dNext >= 0;
+        
+        if (curIn && nextIn) {
+            // Both inside
+            out[outCount++] = *next;
+        } else if (curIn && !nextIn) {
+            // Exiting
+            int denom = dCur - dNext;
+            int t = SafeFixedDiv(dCur, denom);
+            
+            VertexFixed intersection;
+            LerpClipFixed(&intersection, cur, next, t);
+            out[outCount++] = intersection;
+        } else if (!curIn && nextIn) {
+            // Entering
+            int denom = dCur - dNext;
+            int t = SafeFixedDiv(dCur, denom);
+            
+            VertexFixed intersection;
+            LerpClipFixed(&intersection, cur, next, t);
+            out[outCount++] = intersection;
+            out[outCount++] = *next;
+        }
+        // Both outside
+        
+        if (outCount >= 15) break; // Safety limit
+    }
+    
+    return outCount;
+}
+
+static int ClipTriangleToFrustumFixed(const VertexFixed tri[3], VertexFixed* outPoly) {
+    VertexFixed buf1[16], buf2[16];
+    VertexFixed* src = buf1;
+    VertexFixed* dst = buf2;
+    
+    src[0] = tri[0];
+    src[1] = tri[1]; 
+    src[2] = tri[2];
+    int count = 3;
+    
+    for (int i = 0; i < 3; i++) {
+        if (src[i].w == 0) {
+            return 0;
+        }
+    }
+    
+    const int planes[6] = { PLANE_LEFT, PLANE_RIGHT, PLANE_BOTTOM, PLANE_TOP, PLANE_NEAR, PLANE_FAR };
+    
+    for (int p = 0; p < 6; p++) {
+        int newCount = ClipPolygonPlaneFixed(src, count, dst, planes[p]);
+        
+        if (newCount == 0) {
+            return 0;
+        }
+        
+        // Swap buffers
+        VertexFixed* tmp = src;
+        src = dst;
+        dst = tmp;
+        count = newCount;
+        
+        if (count > 15) count = 15; // Safety limit
+    }
+    
+    for (int i = 0; i < count; i++) {
+        outPoly[i] = src[i];
+    }
+    
+    return count;
+}
+
+static void TransformVertex2D(int index, VertexFixed* vertex) {
+    char* ptr = (char*)gfx_vertices + index * gfx_stride;
+    struct VertexColoured* v_col;
+    struct VertexTextured* v_tex;
+    
+    if (gfx_format != VERTEX_FORMAT_TEXTURED) {
+        v_col = (struct VertexColoured*)ptr;
+        vertex->x = FloatToFixed(v_col->x);
+        vertex->y = FloatToFixed(v_col->y);
+        vertex->u = 0;
+        vertex->v = 0;
+        vertex->c = v_col->Col;
+    } else {
+        v_tex = (struct VertexTextured*)ptr;
+        vertex->x = FloatToFixed(v_tex->x);
+        vertex->y = FloatToFixed(v_tex->y);
+        vertex->u = FloatToFixed(v_tex->U);
+        vertex->v = FloatToFixed(v_tex->V);
+        vertex->c = v_tex->Col;
+    }
+}
+
+static int TransformVertex3D(int index, VertexFixed* vertex) {
+    char* ptr = (char*)gfx_vertices + index * gfx_stride;
+    struct VertexColoured* v_col;
+    struct VertexTextured* v_tex;
+    
+    int pos_x, pos_y, pos_z;
+    
+    if (gfx_format != VERTEX_FORMAT_TEXTURED) {
+        v_col = (struct VertexColoured*)ptr;
+        pos_x = FloatToFixed(v_col->x);
+        pos_y = FloatToFixed(v_col->y);
+        pos_z = FloatToFixed(v_col->z);
+        vertex->u = 0;
+        vertex->v = 0;
+        vertex->c = v_col->Col;
+    } else {
+        v_tex = (struct VertexTextured*)ptr;
+        pos_x = FloatToFixed(v_tex->x);
+        pos_y = FloatToFixed(v_tex->y);
+        pos_z = FloatToFixed(v_tex->z);
+        vertex->u = FloatToFixed(v_tex->U) + texOffsetX_fp;
+        vertex->v = FloatToFixed(v_tex->V) + texOffsetY_fp;
+        vertex->c = v_tex->Col;
+    }
+
+    if (ABS(pos_x) > (1 << 28) || ABS(pos_y) > (1 << 28) || ABS(pos_z) > (1 << 28)) {
+        return 0;
+    }
+
+    int64_t x_temp = (int64_t)pos_x * _mvp_fp.m[0][0] + (int64_t)pos_y * _mvp_fp.m[1][0] + 
+                       (int64_t)pos_z * _mvp_fp.m[2][0] + ((int64_t)_mvp_fp.m[3][0] << FP_SHIFT);
+    int64_t y_temp = (int64_t)pos_x * _mvp_fp.m[0][1] + (int64_t)pos_y * _mvp_fp.m[1][1] + 
+                       (int64_t)pos_z * _mvp_fp.m[2][1] + ((int64_t)_mvp_fp.m[3][1] << FP_SHIFT);
+    int64_t z_temp = (int64_t)pos_x * _mvp_fp.m[0][2] + (int64_t)pos_y * _mvp_fp.m[1][2] + 
+                       (int64_t)pos_z * _mvp_fp.m[2][2] + ((int64_t)_mvp_fp.m[3][2] << FP_SHIFT);
+    int64_t w_temp = (int64_t)pos_x * _mvp_fp.m[0][3] + (int64_t)pos_y * _mvp_fp.m[1][3] + 
+                       (int64_t)pos_z * _mvp_fp.m[2][3] + ((int64_t)_mvp_fp.m[3][3] << FP_SHIFT);
+
+    x_temp >>= FP_SHIFT;
+    y_temp >>= FP_SHIFT;
+    z_temp >>= FP_SHIFT;
+    w_temp >>= FP_SHIFT;
+
+    vertex->x = (x_temp > INT_MAX) ? INT_MAX : (x_temp < INT_MIN) ? INT_MIN : (int)x_temp;
+    vertex->y = (y_temp > INT_MAX) ? INT_MAX : (y_temp < INT_MIN) ? INT_MIN : (int)y_temp;
+    vertex->z = (z_temp > INT_MAX) ? INT_MAX : (z_temp < INT_MIN) ? INT_MIN : (int)z_temp;
+    vertex->w = (w_temp > INT_MAX) ? INT_MAX : (w_temp < INT_MIN) ? INT_MIN : (int)w_temp;
+
+    return 1;
+}
+
+static cc_bool ViewportVertex3D(VertexFixed* vertex) {
+    if (vertex->w == 0) return false;
+    if (ABS(vertex->w) < 64) return false; // Too small w
+    
+    int invW = FixedReciprocal(vertex->w);
+    
+    if (ABS(invW) > (FP_ONE << 10)) return false; // 1024x magnification limit
+
+    int64_t x_ndc = ((int64_t)vertex->x * invW) >> FP_SHIFT;
+    int64_t y_ndc = ((int64_t)vertex->y * invW) >> FP_SHIFT;
+    int64_t z_ndc = ((int64_t)vertex->z * invW) >> FP_SHIFT;
+    
+    int64_t screen_x = vp_hwidth_fp + ((x_ndc * vp_hwidth_fp) >> FP_SHIFT);
+    int64_t screen_y = vp_hheight_fp - ((y_ndc * vp_hheight_fp) >> FP_SHIFT);
+    
+    // Clamp
+    if (screen_x < -(fb_width << FP_SHIFT) || screen_x > (fb_width << (FP_SHIFT + 1))) return false;
+    if (screen_y < -(fb_height << FP_SHIFT) || screen_y > (fb_height << (FP_SHIFT + 1))) return false;
+    
+    vertex->x = (int)screen_x;
+    vertex->y = (int)screen_y;
+    vertex->z = (z_ndc > INT_MAX) ? INT_MAX : (z_ndc < INT_MIN) ? INT_MIN : (int)z_ndc;
+    vertex->w = invW;
+    
+    vertex->u = FixedMul(vertex->u, invW);
+    vertex->v = FixedMul(vertex->v, invW);
+    
+    return true;
+}
+
+static void DrawSprite2D(VertexFixed* V0, VertexFixed* V1, VertexFixed* V2) {
+    PackedCol vColor = V0->c;
+    int minX = FixedToInt(V0->x);
+    int minY = FixedToInt(V0->y);
+    int maxX = FixedToInt(V1->x);
+    int maxY = FixedToInt(V2->y);
+
+    if (maxX < 0 || minX > fb_maxX) return;
+    if (maxY < 0 || minY > fb_maxY) return;
+
+    int begTX = FixedMul(V0->u, IntToFixed(curTexWidth)) >> FP_SHIFT;
+    int begTY = FixedMul(V0->v, IntToFixed(curTexHeight)) >> FP_SHIFT;
+    int delTX = (FixedMul(V1->u, IntToFixed(curTexWidth)) >> FP_SHIFT) - begTX;
+    int delTY = (FixedMul(V2->v, IntToFixed(curTexHeight)) >> FP_SHIFT) - begTY;
+
+    int width = maxX - minX, height = maxY - minY;
+
+    int fast = delTX == width && delTY == height && 
+               (begTX + delTX < curTexWidth) && 
+               (begTY + delTY < curTexHeight);
+
+    minX = max(minX, 0); maxX = min(maxX, fb_maxX);
+    minY = max(minY, 0); maxY = min(maxY, fb_maxY);
+
+    int x, y;
+    for (y = minY; y <= maxY; y++) 
+    {
+        int texY = fast ? (begTY + (y - minY)) : (((begTY + delTY * (y - minY) / height)) & texHeightMask);
+        for (x = minX; x <= maxX; x++) 
+        {
+            int texX = fast ? (begTX + (x - minX)) : (((begTX + delTX * (x - minX) / width)) & texWidthMask);
+            int texIndex = texY * curTexWidth + texX;
+
+            BitmapCol color = curTexPixels[texIndex];
+            int R, G, B, A;
+
+            A = BitmapCol_A(color);
+            if (gfx_alphaBlend && A == 0) continue;
+            int cb_index = y * cb_stride + x;
+
+            if (gfx_alphaBlend && A != 255) {
+                BitmapCol dst = colorBuffer[cb_index];
+                int dstR = BitmapCol_R(dst);
+                int dstG = BitmapCol_G(dst);
+                int dstB = BitmapCol_B(dst);
+
+                R = BitmapCol_R(color);
+                G = BitmapCol_G(color);
+                B = BitmapCol_B(color);
+
+                R = (R * A + dstR * (255 - A)) >> 8;
+                G = (G * A + dstG * (255 - A)) >> 8;
+                B = (B * A + dstB * (255 - A)) >> 8;
+                color = BitmapCol_Make(R, G, B, 0xFF);
+            }
+
+            if (vColor != PACKEDCOL_WHITE) {
+                int r1 = PackedCol_R(vColor), r2 = BitmapCol_R(color);
+                R = ( r1 * r2 ) >> 8;
+                int g1 = PackedCol_G(vColor), g2 = BitmapCol_G(color);
+                G = ( g1 * g2 ) >> 8;
+                int b1 = PackedCol_B(vColor), b2 = BitmapCol_B(color);
+                B = ( b1 * b2 ) >> 8;
+
+                color = BitmapCol_Make(R, G, B, 0xFF);
+            }
+
+            colorBuffer[cb_index] = color;
+        }
+    }
+}
+
+#define edgeFunctionFixed(ax,ay, bx,by, cx,cy) \
+    (FixedMul((bx) - (ax), (cy) - (ay)) - FixedMul((by) - (ay), (cx) - (ax)))
+    
+#define MultiplyColors(vColor, tColor) \
+    a1 = PackedCol_A(vColor); \
+    a2 = BitmapCol_A(tColor); \
+    A  = ( a1 * a2 ) >> 8;    \
+\
+    r1 = PackedCol_R(vColor); \
+    r2 = BitmapCol_R(tColor); \
+    R  = ( r1 * r2 ) >> 8;    \
+\
+    g1 = PackedCol_G(vColor); \
+    g2 = BitmapCol_G(tColor); \
+    G  = ( g1 * g2 ) >> 8;    \
+\
+    b1 = PackedCol_B(vColor); \
+    b2 = BitmapCol_B(tColor); \
+    B  = ( b1 * b2 ) >> 8;    \
+
+static void DrawTriangle3D(VertexFixed* V0, VertexFixed* V1, VertexFixed* V2) {
+    int x0_fp = V0->x, y0_fp = V0->y;
+    int x1_fp = V1->x, y1_fp = V1->y;
+    int x2_fp = V2->x, y2_fp = V2->y;
+
+    int minX = FixedToInt(min(x0_fp, min(x1_fp, x2_fp)));
+    int minY = FixedToInt(min(y0_fp, min(y1_fp, y2_fp)));
+    int maxX = FixedToInt(max(x0_fp, max(x1_fp, x2_fp)));
+    int maxY = FixedToInt(max(y0_fp, max(y1_fp, y2_fp)));
+
+    if (maxX < 0 || minX > fb_maxX) return;
+    if (maxY < 0 || minY > fb_maxY) return;
+
+    minX = max(minX, 0); maxX = min(maxX, fb_maxX);
+    minY = max(minY, 0); maxY = min(maxY, fb_maxY);
+
+    int area = edgeFunctionFixed(x0_fp, y0_fp, x1_fp, y1_fp, x2_fp, y2_fp);
+    if (area == 0) return;
+
+    int factor = FixedReciprocal(area);
+
+    int w0 = V0->w, w1 = V1->w, w2 = V2->w;
+    if (w0 <= 0 && w1 <= 0 && w2 <= 0) return;
+
+    int z0 = V0->z, z1 = V1->z, z2 = V2->z;
+    PackedCol color = V0->c;
+
+    int u0 = FixedMul(V0->u, IntToFixed(curTexWidth));
+    int v0 = FixedMul(V0->v, IntToFixed(curTexHeight));
+    int u1 = FixedMul(V1->u, IntToFixed(curTexWidth));
+    int v1 = FixedMul(V1->v, IntToFixed(curTexHeight));
+    int u2 = FixedMul(V2->u, IntToFixed(curTexWidth));
+    int v2 = FixedMul(V2->v, IntToFixed(curTexHeight));
+
+    int dx01  = y0_fp - y1_fp, dy01 = x1_fp - x0_fp;
+    int dx12  = y1_fp - y2_fp, dy12 = x2_fp - x1_fp;
+    int dx20  = y2_fp - y0_fp, dy20 = x0_fp - x2_fp;
+
+    int minX_fp = IntToFixed(minX) + FP_HALF;
+    int minY_fp = IntToFixed(minY) + FP_HALF;
+
+    int bc0_start = edgeFunctionFixed(x1_fp, y1_fp, x2_fp, y2_fp, minX_fp, minY_fp);
+    int bc1_start = edgeFunctionFixed(x2_fp, y2_fp, x0_fp, y0_fp, minX_fp, minY_fp);
+    int bc2_start = edgeFunctionFixed(x0_fp, y0_fp, x1_fp, y1_fp, minX_fp, minY_fp);
+
+
+    int R, G, B, A, x, y;
+    int a1, r1, g1, b1;
+    int a2, r2, g2, b2;
+    cc_bool texturing = gfx_format == VERTEX_FORMAT_TEXTURED;
+
+    if (!texturing) {
+        R = PackedCol_R(color);
+        G = PackedCol_G(color);
+        B = PackedCol_B(color);
+        A = PackedCol_A(color);
+    } else if (texSinglePixel) {
+        int rawY0 = FixedDiv(v0, w0);
+        int rawY1 = FixedDiv(v1, w1);
+        int rawY = min(rawY0, rawY1);
+        int texY = (FixedToInt(rawY) + 1) & texHeightMask;
+        MultiplyColors(color, curTexPixels[texY * curTexWidth]);
+        texturing = false;
+    }
+
+    for (y = minY; y <= maxY; y++, bc0_start += dy12, bc1_start += dy20, bc2_start += dy01) 
+    {
+        int bc0 = bc0_start;
+        int bc1 = bc1_start;
+        int bc2 = bc2_start;
+
+        for (x = minX; x <= maxX; x++, bc0 += dx12, bc1 += dx20, bc2 += dx01) 
+        {
+            int ic0 = FixedMul(bc0, factor);
+            int ic1 = FixedMul(bc1, factor);
+            int ic2 = FixedMul(bc2, factor);
+            if (ic0 < 0 || ic1 < 0 || ic2 < 0) continue;
+            int db_index = y * db_stride + x;
+
+            int w_interp = FixedMul(ic0, w0) + FixedMul(ic1, w1) + FixedMul(ic2, w2);
+            if (w_interp == 0) continue;
+            int w = FixedReciprocal(w_interp);
+            int z_interp = FixedMul(ic0, z0) + FixedMul(ic1, z1) + FixedMul(ic2, z2);
+            int z = FixedMul(z_interp, w);
+
+            if (depthTest && (z < 0 || z > depthBuffer[db_index])) continue;
+            if (!colWrite) {
+                if (depthWrite) depthBuffer[db_index] = z;
+                continue;
+            }
+
+            if (texturing) {
+                int u_interp = FixedMul(ic0, u0) + FixedMul(ic1, u1) + FixedMul(ic2, u2);
+                int v_interp = FixedMul(ic0, v0) + FixedMul(ic1, v1) + FixedMul(ic2, v2);
+                int u = FixedMul(u_interp, w);
+                int v = FixedMul(v_interp, w);
+                
+                int texX = FixedToInt(u) & texWidthMask;
+                int texY = FixedToInt(v) & texHeightMask;
+
+                int texIndex = texY * curTexWidth + texX;
+                BitmapCol tColor = curTexPixels[texIndex];
+
+                MultiplyColors(color, tColor);
+            }
+
+            if (gfx_alphaTest && A < 0x80) continue;
+            if (depthWrite) depthBuffer[db_index] = z;
+            int cb_index = y * cb_stride + x;
+            
+            if (!gfx_alphaBlend) {
+                colorBuffer[cb_index] = BitmapCol_Make(R, G, B, 0xFF);
+                continue;
+            }
+
+            BitmapCol dst = colorBuffer[cb_index];
+            int dstR = BitmapCol_R(dst);
+            int dstG = BitmapCol_G(dst);
+            int dstB = BitmapCol_B(dst);
+
+            int finR = (R * A + dstR * (255 - A)) >> 8;
+            int finG = (G * A + dstG * (255 - A)) >> 8;
+            int finB = (B * A + dstB * (255 - A)) >> 8;
+            colorBuffer[cb_index] = BitmapCol_Make(finR, finG, finB, 0xFF);
+        }
+    }
+}
+static void DrawTriangle2D(VertexFixed* V0, VertexFixed* V1, VertexFixed* V2) {
+    int x0_fp = V0->x, y0_fp = V0->y;
+    int x1_fp = V1->x, y1_fp = V1->y;
+    int x2_fp = V2->x, y2_fp = V2->y;
+
+    int minX = FixedToInt(min(x0_fp, min(x1_fp, x2_fp)));
+    int minY = FixedToInt(min(y0_fp, min(y1_fp, y2_fp)));
+    int maxX = FixedToInt(max(x0_fp, max(x1_fp, x2_fp)));
+    int maxY = FixedToInt(max(y0_fp, max(y1_fp, y2_fp)));
+
+    if (maxX < 0 || minX > fb_maxX) return;
+    if (maxY < 0 || minY > fb_maxY) return;
+
+    minX = max(minX, 0); maxX = min(maxX, fb_maxX);
+    minY = max(minY, 0); maxY = min(maxY, fb_maxY);
+
+    int u0 = FixedMul(V0->u, IntToFixed(curTexWidth));
+    int v0 = FixedMul(V0->v, IntToFixed(curTexHeight));
+    int u1 = FixedMul(V1->u, IntToFixed(curTexWidth));
+    int v1 = FixedMul(V1->v, IntToFixed(curTexHeight));
+    int u2 = FixedMul(V2->u, IntToFixed(curTexWidth));
+    int v2 = FixedMul(V2->v, IntToFixed(curTexHeight));
+    PackedCol color = V0->c;
+
+    int area = edgeFunctionFixed(x0_fp,y0_fp, x1_fp,y1_fp, x2_fp,y2_fp);
+    if (area == 0) return;
+    int factor = FixedReciprocal(area);
+
+    int dx01  = y0_fp - y1_fp, dy01 = x1_fp - x0_fp;
+    int dx12  = y1_fp - y2_fp, dy12 = x2_fp - x1_fp;
+    int dx20  = y2_fp - y0_fp, dy20 = x0_fp - x2_fp;
+
+    int minX_fp = IntToFixed(minX) + FP_HALF;
+    int minY_fp = IntToFixed(minY) + FP_HALF;
+
+    int bc0_start = edgeFunctionFixed(x1_fp,y1_fp, x2_fp,y2_fp, minX_fp,minY_fp);
+    int bc1_start = edgeFunctionFixed(x2_fp,y2_fp, x0_fp,y0_fp, minX_fp,minY_fp);
+    int bc2_start = edgeFunctionFixed(x0_fp,y0_fp, x1_fp,y1_fp, minX_fp,minY_fp);
+
+    int x, y;
+    for (y = minY; y <= maxY; y++, bc0_start += dy12, bc1_start += dy20, bc2_start += dy01) 
+    {
+        int bc0 = bc0_start;
+        int bc1 = bc1_start;
+        int bc2 = bc2_start;
+
+        for (x = minX; x <= maxX; x++, bc0 += dx12, bc1 += dx20, bc2 += dx01) 
+        {
+            int ic0 = FixedMul(bc0, factor);
+            int ic1 = FixedMul(bc1, factor);
+            int ic2 = FixedMul(bc2, factor);
+
+            if (ic0 < 0 || ic1 < 0 || ic2 < 0) continue;
+            int cb_index = y * cb_stride + x;
+
+            int R, G, B, A;
+            if (gfx_format == VERTEX_FORMAT_TEXTURED) {
+                int u = FixedMul(ic0, u0) + FixedMul(ic1, u1) + FixedMul(ic2, u2);
+                int v = FixedMul(ic0, v0) + FixedMul(ic1, v1) + FixedMul(ic2, v2);
+                int texX = FixedToInt(u) & texWidthMask;
+                int texY = FixedToInt(v) & texHeightMask;
+                int texIndex = texY * curTexWidth + texX;
+
+                BitmapCol tColor = curTexPixels[texIndex];
+                int a1 = PackedCol_A(color), a2 = BitmapCol_A(tColor);
+                A = ( a1 * a2 ) >> 8;
+                int r1 = PackedCol_R(color), r2 = BitmapCol_R(tColor);
+                R = ( r1 * r2 ) >> 8;
+                int g1 = PackedCol_G(color), g2 = BitmapCol_G(tColor);
+                G = ( g1 * g2 ) >> 8;
+                int b1 = PackedCol_B(color), b2 = BitmapCol_B(tColor);
+                B = ( b1 * b2 ) >> 8;
+            } else {
+                R = PackedCol_R(color);
+                G = PackedCol_G(color);
+                B = PackedCol_B(color);
+                A = PackedCol_A(color);
+            }
+
+            if (gfx_alphaTest && A < 0x80) continue;
+            if (gfx_alphaBlend && A == 0)  continue;
+
+            if (gfx_alphaBlend && A != 255) {
+                BitmapCol dst = colorBuffer[cb_index];
+                int dstR = BitmapCol_R(dst);
+                int dstG = BitmapCol_G(dst);
+                int dstB = BitmapCol_B(dst);
+
+                R = (R * A + dstR * (255 - A)) >> 8;
+                G = (G * A + dstG * (255 - A)) >> 8;
+                B = (B * A + dstB * (255 - A)) >> 8;
+            }
+
+            colorBuffer[cb_index] = BitmapCol_Make(R, G, B, 0xFF);
+        }
+    }
+}
+
+static void ProcessClippedTriangleAndDraw(const VertexFixed* inVerts, int polyCount) {
+    if (polyCount < 3) return;
+    
+    for (int i = 1; i + 1 < polyCount; i++) {
+        VertexFixed A = inVerts[0];
+        VertexFixed B = inVerts[i];
+        VertexFixed C = inVerts[i + 1];
+
+        if (faceCulling) {
+            if (A.w > 0 && B.w > 0 && C.w > 0) {
+                int invA = FixedReciprocal(A.w);
+                int invB = FixedReciprocal(B.w);
+                int invC = FixedReciprocal(C.w);
+
+                int ax = FixedMul(A.x, invA);
+                int ay = FixedMul(A.y, invA);
+                int bx = FixedMul(B.x, invB);
+                int by = FixedMul(B.y, invB);
+                int cx = FixedMul(C.x, invC);
+                int cy = FixedMul(C.y, invC);
+
+                int area_ndc = edgeFunctionFixed(ax, ay, bx, by, cx, cy);
+                if (area_ndc < 0) continue; /* 裏向き → スキップ */
+            }
+        }
+
+        if (!ViewportVertex3D(&A) || !ViewportVertex3D(&B) || !ViewportVertex3D(&C)) {
+            continue;
+        }
+        
+        int minX = FixedToInt(min(A.x, min(B.x, C.x)));
+        int minY = FixedToInt(min(A.y, min(B.y, C.y)));
+        int maxX = FixedToInt(max(A.x, max(B.x, C.x)));
+        int maxY = FixedToInt(max(A.y, max(B.y, C.y)));
+        
+        if (maxX < 0 || minX > fb_maxX || maxY < 0 || minY > fb_maxY) {
+            continue;
+        }
+        
+        // too small
+        int area = edgeFunctionFixed(A.x, A.y, B.x, B.y, C.x, C.y);
+        if (ABS(area) <= FP_ONE) continue;
+        
+        DrawTriangle3D(&A, &B, &C);
+    }
+}
+
+static void DrawClippedFixed(int mask, VertexFixed* v0, VertexFixed* v1, VertexFixed* v2, VertexFixed* v3) {
+    VertexFixed inTri[3], outPoly[16];
+    int polyCount;
+    
+    // Triangle 1: v0, v1, v2
+    inTri[0] = *v0;
+    inTri[1] = *v1;
+    inTri[2] = *v2;
+    
+    polyCount = ClipTriangleToFrustumFixed(inTri, outPoly);
+    if (polyCount > 0) {
+        ProcessClippedTriangleAndDraw(outPoly, polyCount);
+    }
+    
+    // triangle 2: v2, v3, v0
+    inTri[0] = *v2;
+    inTri[1] = *v3;
+    inTri[2] = *v0;
+    
+    polyCount = ClipTriangleToFrustumFixed(inTri, outPoly);
+    if (polyCount > 0) {
+        ProcessClippedTriangleAndDraw(outPoly, polyCount);
+    }
+}
+
+#define V0_VIS (1 << 0)
+#define V1_VIS (1 << 1)
+#define V2_VIS (1 << 2)
+#define V3_VIS (1 << 3)
+static void ClipLineFixed(const VertexFixed* v1, const VertexFixed* v2, VertexFixed* out, int d1, int d2) {
+    int denom = d1 - d2;
+    int t = denom == 0 ? FP_HALF : FixedDiv(d1, denom);
+    int invt = FP_ONE - t;
+
+    out->x = FixedMul(invt, v1->x) + FixedMul(t, v2->x);
+    out->y = FixedMul(invt, v1->y) + FixedMul(t, v2->y);
+    out->z = FixedMul(invt, v1->z) + FixedMul(t, v2->z);
+    out->w = FixedMul(invt, v1->w) + FixedMul(t, v2->w);
+    out->u = FixedMul(invt, v1->u) + FixedMul(t, v2->u);
+    out->v = FixedMul(invt, v1->v) + FixedMul(t, v2->v);
+    out->c = v1->c; //TODO: 色補完する？
+}
+
+void DrawQuadsFixed(int startVertex, int verticesCount, DrawHints hints) {
+    VertexFixed vertices[4];
+    int i, j = startVertex;
+
+    if (gfx_rendering2D && (hints & (DRAW_HINT_SPRITE|DRAW_HINT_RECT))) {
+        for (i = 0; i < verticesCount / 4; i++, j += 4) {
+            TransformVertex2D(j + 0, &vertices[0]);
+            TransformVertex2D(j + 1, &vertices[1]);
+            TransformVertex2D(j + 2, &vertices[2]);
+            DrawSprite2D(&vertices[0], &vertices[1], &vertices[2]);
+        }
+    } else if (gfx_rendering2D) {
+        for (i = 0; i < verticesCount / 4; i++, j += 4) {
+            TransformVertex2D(j + 0, &vertices[0]);
+            TransformVertex2D(j + 1, &vertices[1]);
+            TransformVertex2D(j + 2, &vertices[2]);
+            TransformVertex2D(j + 3, &vertices[3]);
+            DrawTriangle2D(&vertices[0], &vertices[2], &vertices[1]);
+            DrawTriangle2D(&vertices[2], &vertices[0], &vertices[3]);
+        }
+    } else {
+        for (i = 0; i < verticesCount / 4; i++, j += 4) {
+            TransformVertex3D(j + 0, &vertices[0]);
+            TransformVertex3D(j + 1, &vertices[1]);
+            TransformVertex3D(j + 2, &vertices[2]);
+            TransformVertex3D(j + 3, &vertices[3]);
+            
+            DrawClippedFixed(0x0F, &vertices[0], &vertices[1], &vertices[2], &vertices[3]);
+        }
+    }
+}
+void Gfx_SetVertexFormat(VertexFormat fmt) {
+    gfx_format = fmt;
+    gfx_stride = strideSizes[fmt];
+}
+
+void Gfx_DrawVb_Lines(int verticesCount) { } /* TODO */
+
+void Gfx_DrawVb_IndexedTris_Range(int verticesCount, int startVertex, DrawHints hints) {
+    DrawQuadsFixed(startVertex, verticesCount, hints);
+}
+
+void Gfx_DrawVb_IndexedTris(int verticesCount) {
+    DrawQuadsFixed(0, verticesCount, DRAW_HINT_NONE);
+}
+
+void Gfx_DrawIndexedTris_T2fC4b(int verticesCount, int startVertex) {
+    DrawQuadsFixed(startVertex, verticesCount, DRAW_HINT_NONE);
+}
+
+/*########################################################################################################################*
+*---------------------------------------------------------Other/Misc------------------------------------------------------*
+*#########################################################################################################################*/
+static BitmapCol* CB_GetRow(struct Bitmap* bmp, int y, void* ctx) {
+    return colorBuffer + cb_stride * y;
+}
+
+cc_result Gfx_TakeScreenshot(struct Stream* output) {
+    struct Bitmap bmp;
+    Bitmap_Init(bmp, fb_width, fb_height, NULL);
+    return Png_Encode(&bmp, output, CB_GetRow, false, NULL);
+}
+
+cc_bool Gfx_WarnIfNecessary(void) { return false; }
+cc_bool Gfx_GetUIOptions(struct MenuOptionsScreen* s) { return false; }
+
+void Gfx_BeginFrame(void) { }
+
+void Gfx_EndFrame(void) {
+    Rect2D r = { 0, 0, fb_width, fb_height };
+    Window_DrawFramebuffer(r, &fb_bmp);
+}
+
+void Gfx_SetVSync(cc_bool vsync) {
+    gfx_vsync = vsync;
+}
+
+void Gfx_OnWindowResize(void) {
+    if (depthBuffer) DestroyBuffers();
+
+    fb_width   = Game.Width;
+    fb_height  = Game.Height;
+
+    Window_AllocFramebuffer(&fb_bmp, Game.Width, Game.Height);
+    colorBuffer = fb_bmp.scan0;
+    cb_stride   = fb_bmp.width;
+
+    depthBuffer = Mem_Alloc(fb_width * fb_height, 4, "depth buffer");
+    db_stride   = fb_width;
+
+    Gfx_SetViewport(0, 0, Game.Width, Game.Height);
+    Gfx_SetScissor (0, 0, Game.Width, Game.Height);
+}
+
+void Gfx_SetViewport(int x, int y, int w, int h) {
+    vp_hwidth_fp  = FloatToFixed(w / 2.0f);
+    vp_hheight_fp = FloatToFixed(h / 2.0f);
+}
+
+void Gfx_SetScissor (int x, int y, int w, int h) {
+    fb_maxX = x + w - 1;
+    fb_maxY = y + h - 1;
+}
+
+void Gfx_GetApiInfo(cc_string* info) {
+    int pointerSize = sizeof(void*) * 8;
+    String_Format1(info, "-- Using software fixed-point (%i bit) --\n", &pointerSize);
+    PrintMaxTextureInfo(info);
+}
+
+cc_bool Gfx_TryRestoreContext(void) { return true; }
+#endif


### PR DESCRIPTION
This pull request adds a new software renderer based on Graphics_SoftGPU.C, optimized for devices without a floating-point unit.

- Implements fixed-point arithmetic for internal processing.
- Includes more accurate and robust clipping logic.

Observed a 5-10x speedup on ARM devices without FPU.

Further optimization may be possible.