### PR TITLE
DSi WiFi update

### DIFF
--- a/.github/workflows/build_nds.yml
+++ b/.github/workflows/build_nds.yml
@@ -28,33 +28,19 @@ jobs:
         id: compile
         run: |
           make ds
-          export BUILD_DSI=1
-          make ds
  
          
       - uses: ./.github/actions/upload_build
         if: ${{ always() && steps.compile.outcome == 'success' }}
         with:
-          SOURCE_FILE: 'ClassiCube-nds.nds'
-          DEST_NAME: 'ClassiCube-nds.nds'
+          SOURCE_FILE: 'ClassiCube.nds'
+          DEST_NAME: 'ClassiCube.nds'
           
       - uses: ./.github/actions/upload_build
         if: ${{ always() && steps.compile.outcome == 'success' }}
         with:
           SOURCE_FILE: 'build/nds/cc-arm9.elf'
-          DEST_NAME: 'ClassiCube-nds.elf'
-
-      - uses: ./.github/actions/upload_build
-        if: ${{ always() && steps.compile.outcome == 'success' }}
-        with:
-          SOURCE_FILE: 'ClassiCube-dsi.nds'
-          DEST_NAME: 'ClassiCube-dsi.nds'
-          
-      - uses: ./.github/actions/upload_build
-        if: ${{ always() && steps.compile.outcome == 'success' }}
-        with:
-          SOURCE_FILE: 'build/dsi/cc-arm9.elf'
-          DEST_NAME: 'ClassiCube-dsi.elf'
+          DEST_NAME: 'ClassiCube.elf'
           
           
       - uses: ./.github/actions/notify_success

--- a/misc/nds/Makefile
+++ b/misc/nds/Makefile
@@ -21,13 +21,8 @@ SDIMAGE		:= image.bin
 
 # Build artfacts
 # --------------
-ifdef BUILD_DSI
-BUILDDIR	:= build/dsi
-ROM			:= ClassiCube-dsi.nds
-else
 BUILDDIR	:= build/nds
-ROM			:= ClassiCube-nds.nds
-endif
+ROM			:= ClassiCube.nds
 
 # Targets
 # -------

--- a/misc/nds/Makefile.arm7
+++ b/misc/nds/Makefile.arm7
@@ -8,19 +8,10 @@ ARM_NONE_EABI_PATH		?= $(WONDERFUL_TOOLCHAIN)/toolchain/gcc-arm-none-eabi/bin/
 
 SOURCEDIRS	:= misc/nds
 INCLUDEDIRS	:=
-DSIWIFI		:= third_party/dsiwifi
 
-ifdef BUILD_DSI
-SOURCEDIRS	+= $(DSIWIFI)/arm_iop/source $(DSIWIFI)/common/source $(DSIWIFI)/arm_iop/source/ath $(DSIWIFI)/arm_iop/source/crypto $(DSIWIFI)/arm_iop/source/ieee
-INCLUDEDIRS	+= $(DSIWIFI)/arm_iop/source  $(DSIWIFI)/arm_iop/include $(DSIWIFI)/common/source $(DSIWIFI)/include $(DSIWIFI)/include/lwip
-BUILDDIR	:= build/dsi
-LIBS		:= -lc -lnds7
-LIBDIRS		:= $(BLOCKSDS)/libs/libnds
-else
 BUILDDIR	:= build/nds
 LIBS		:= -lc -lnds7 -ldswifi7
 LIBDIRS		:= $(BLOCKSDS)/libs/libnds $(BLOCKSDS)/libs/dswifi
-endif
 
 NAME		:= cc-arm7
 ELF		:= $(BUILDDIR)/$(NAME).elf

--- a/misc/nds/Makefile.arm9
+++ b/misc/nds/Makefile.arm9
@@ -8,21 +8,11 @@ ARM_NONE_EABI_PATH		?= $(WONDERFUL_TOOLCHAIN)/toolchain/gcc-arm-none-eabi/bin/
 
 SOURCEDIRS	:= src src/nds
 INCLUDEDIRS     :=
-DSIWIFI		:= third_party/dsiwifi
 
-ifdef BUILD_DSI
-SOURCEDIRS	+= $(DSIWIFI)/arm_host/source $(DSIWIFI)/common/source $(DSIWIFI)/arm_host/source/nds $(DSIWIFI)/arm_host/source/lwip $(DSIWIFI)/arm_host/source/lwip/ipv4 $(DSIWIFI)/arm_host/source/lwip/ipv6 $(DSIWIFI)/arm_host/source/lwip/netif $(DSIWIFI)/arm_host/source/lwip/netif/ppp $(DSIWIFI)/arm_host/source/lwip/api
-INCLUDEDIRS	+= $(DSIWIFI)/arm_host/include $(DSIWIFI)/common/source $(DSIWIFI)/include $(DSIWIFI)/include/lwip
-BUILDDIR	:= build/dsi
-DEFINES		:= -DPLAT_NDS -DBUILD_DSI
-LIBS		:= -lnds9 -lc
-LIBDIRS		:= $(BLOCKSDS)/libs/libnds
-else
 BUILDDIR	:= build/nds
 DEFINES		:= -DPLAT_NDS
 LIBS		:= -ldswifi9 -lnds9 -lc
 LIBDIRS		:= $(BLOCKSDS)/libs/dswifi $(BLOCKSDS)/libs/libnds
-endif
 
 NAME		:= cc-arm9
 ELF		:= $(BUILDDIR)/$(NAME).elf

--- a/src/nds/Graphics_NDS.c
+++ b/src/nds/Graphics_NDS.c
@@ -159,7 +159,7 @@ void Gfx_EndFrame(void) {
 
 	GFX_FLUSH = 0;
 	// TODO not needed?
-	swiWaitForVBlank();
+	cothread_yield_irq(IRQ_VBLANK);
 }
 
 

--- a/src/nds/Platform_NDS.c
+++ b/src/nds/Platform_NDS.c
@@ -30,11 +30,8 @@
 #include <nds/arm9/sdmmc.h>
 #include <nds/arm9/exceptions.h>
 #include <fat.h>
-#ifdef BUILD_DSI
 #include <dsiwifi9.h>
-#else
 #include <dswifi9.h>
-#endif
 #include <netdb.h>
 #include <netinet/in.h>
 #include <sys/stat.h>
@@ -510,11 +507,7 @@ cc_result Socket_Write(cc_socket s, const cc_uint8* data, cc_uint32 count, cc_ui
 
 void Socket_Close(cc_socket s) {
 	shutdown(s, 2); // SHUT_RDWR = 2
-#ifdef BUILD_DSI
-	lwip_close(s);
-#else
 	closesocket(s);
-#endif
 }
 
 static cc_result Socket_Poll(cc_socket s, int mode, cc_bool* success) {
@@ -569,27 +562,15 @@ static void LogWifiStatus(int status) {
 }
 
 static void InitNetworking(void) {
-#ifdef BUILD_DSI
-    if (!DSiWifi_InitDefault(INIT_ONLY)) {
-#else
-    if (!Wifi_InitDefault(INIT_ONLY)) {
-#endif
+    if (!Wifi_InitDefault(INIT_ONLY | WIFI_ATTEMPT_DSI_MODE)) {
         Platform_LogConst("Initing WIFI failed"); 
 		net_supported = false; return;
     }
-#ifdef BUILD_DSI
-    DSiWifi_AutoConnect();
-#else
     Wifi_AutoConnect();
-#endif
 
     for (int i = 0; i < 300; i++)
     {
-#ifdef BUILD_DSI
-        int status = DSiWifi_AssocStatus();
-#else
         int status = Wifi_AssocStatus();
-#endif	
 		LogWifiStatus(status);
         if (status == ASSOCSTATUS_ASSOCIATED) return;
 
@@ -658,4 +639,5 @@ static cc_result GetMachineID(cc_uint32* key) {
 cc_result Platform_GetEntropy(void* data, int len) {
 	return ERR_NOT_SUPPORTED;
 }
+
 

--- a/src/nds/Platform_NDS.c
+++ b/src/nds/Platform_NDS.c
@@ -589,11 +589,7 @@ static void InitNetworking(void) {
 *#########################################################################################################################*/
 void Platform_Init(void) {
 	cc_bool dsiMode = isDSiMode();
-#ifdef BUILD_DSI
-	Platform_Log1("Running in %c mode with DSi wifi", dsiMode ? "DSi" : "DS");
-#else
-	Platform_Log1("Running in %c mode with NDS wifi", dsiMode ? "DSi" : "DS");
-#endif
+	Platform_Log1("Running in %c mode", dsiMode ? "DSi" : "DS");
 
 	InitFilesystem();
     InitNetworking();

--- a/src/nds/Platform_NDS.c
+++ b/src/nds/Platform_NDS.c
@@ -30,7 +30,6 @@
 #include <nds/arm9/sdmmc.h>
 #include <nds/arm9/exceptions.h>
 #include <fat.h>
-#include <dsiwifi9.h>
 #include <dswifi9.h>
 #include <netdb.h>
 #include <netinet/in.h>
@@ -639,5 +638,6 @@ static cc_result GetMachineID(cc_uint32* key) {
 cc_result Platform_GetEntropy(void* data, int len) {
 	return ERR_NOT_SUPPORTED;
 }
+
 
 

--- a/src/nds/Window_NDS.c
+++ b/src/nds/Window_NDS.c
@@ -14,6 +14,7 @@
 #include <nds/arm9/keyboard.h>
 #include <nds/interrupts.h>
 #include <nds/system.h>
+#include <nds/cothread.h>
 #include <fat.h>
 
 #define LAYER_CON  0
@@ -312,7 +313,7 @@ void Window_AllocFramebuffer(struct Bitmap* bmp, int width, int height) {
 }
 
 void Window_DrawFramebuffer(Rect2D r, struct Bitmap* bmp) {
-	swiWaitForVBlank();
+	cothread_yield_irq(IRQ_VBLANK);
 	 
 	for (int y = r.y; y < r.y + r.height; y++)
 	{


### PR DESCRIPTION
BlocksDS v1.15.0 has recently just released, which adds support for connecting to WPA/WPA2 networks on DSi mode.

Summary of changes
* dswifi is initialized with `Wifi_InitDefault(INIT_ONLY | WIFI_ATTEMPT_DSI_MODE)`. It automatically checks if the game is running in DSi mode in order to support WPA/WPA2 networks
* Increased the connection wait timer to 15 seconds
* dswifi now uses lwIP, which requires multithreading. As such, the majority of `swiWaitForVBlank()` calls were replaced with `cothread_yield_irq(IRQ_VBLANK)`
* Removed the separate DSi build