### PR TITLE
webclient: Improve local developer experience

### DIFF
--- a/.github/workflows/build_webclient.yml
+++ b/.github/workflows/build_webclient.yml
@@ -20,15 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Compiles webclient
-        env:
-          SRCS: "src/*.c src/webclient/*.c"
         run: |
-          emcc ${{ env.SRCS }} -o ClassiCube.js -s WASM=0 -s NO_EXIT_RUNTIME=1 -s LEGACY_VM_SUPPORT=1 -s ALLOW_MEMORY_GROWTH=1 -s ABORTING_MALLOC=0 -s ENVIRONMENT=web -s TOTAL_STACK=256Kb --js-library src/webclient/interop_web.js -Os -g2 -s SINGLE_FILE
-          sed -i 's#eventHandler.useCapture);#{ useCapture: eventHandler.useCapture, passive: false });#g' ClassiCube.js
-          
+          make web dist LEGACY=1
+
       - uses: ./.github/actions/upload_build
         with:
-          SOURCE_FILE: 'ClassiCube.js'
+          SOURCE_FILE: 'build/web/dist/ClassiCube.js'
           DEST_NAME: 'ClassiCube.js'
           
           

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ ifeq ($(HOST),linux)
     JOBS := $(shell nproc)
 else ifeq ($(HOST),darwin)
     JOBS := $(shell sysctl -n hw.logicalcpu)
+else ifeq ($(HOST),windows)
+    JOBS := $(NUMBER_OF_PROCESSORS)
 endif
 # default to 1 job (1 per core)
 ifeq ($(strip $(JOBS)),)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean run
+.PHONY: clean run dist
 
 
 ifeq ($(OS),Windows_NT)
@@ -173,5 +173,14 @@ run:
 else
 run:
 	@echo "NOTE: Skipping 'run' due to not being the only goal (all goals: $(MAKECMDGOALS))"
+endif
+
+# Compiles for platform and then packages a deployable folder
+ifeq ($(MAKECMDGOALS),dist)
+dist:
+	$(MAKE) $(PLAT) dist
+else
+dist:
+	@echo "NOTE: Skipping 'dist' due to not being the only goal (all goals: $(MAKECMDGOALS))"
 endif
 

--- a/doc/hosting-webclient.md
+++ b/doc/hosting-webclient.md
@@ -1,29 +1,5 @@
 Hosting your own version of the ClassiCube webclient is relatively straightforward.
 
-### Testing the webclient locally
-
-After compiling the webclient do `make web run`. This serves the compiled webclient on a local web server using emscripten's `emrun`, and then opens it in your browser.
-
-The webclient downloads the default texture pack from `/static/default.zip`, so you need to provide that file too. For example:
-```
-mkdir -p static
-curl -o static/default.zip https://classicube.net/static/default.zip
-```
-
-The generated ClassiCube.html page starts the game in singleplayer with the default username. To test multiplayer, you will need a webpage that provides server connection arguments.
-
-### Hosting the webclient
-
-Run `make web dist` to package the compiled webclient into a `build/web/dist` folder, which can then be uploaded to a website.
-
-- By default the game is compiled to WebAssembly (`ClassiCube.js` and `ClassiCube.wasm`). Add `RELEASE=1` for optimised output.
-- Add `LEGACY=1` to produce a build equivalent to the webclient deployed to classicube.net, a single optimised `ClassiCube.js` file (either asm.js or wasm2js depending on your emscripten version) that's slower but compatible with older browsers.
-- Make sure to run `make web clean` first when rebuilding with different flags/options.
-
-The folder contains a basic singleplayer webpage (`index.html`), the compiled game, and the texture pack (if `static/default.zip` exists). The game loads the texture pack from `/static/default.zip` at the website root, so upload the folder contents to the root (or see below for changing the url).
-
-TODO: more advanced sample (authentication, custom game.js, skin server)
-
 ### Example setup
 
 At minimum, a deployment needs 3 things:
@@ -36,7 +12,7 @@ When building from source, `make web dist` provides all three. You can also reho
 * `example.com/static/classisphere.js`
 * `example.com/static/default.zip`
 
-For simplicitly,
+For simplicity,
 1) Download `cs.classicube.net/client/latest/ClassiCube.js`, then upload it to `static/classisphere.js` on the webserver
 2) Download `classicube.net/static/default.zip`, then upload it to `static/default.zip` on the webserver
 
@@ -92,18 +68,65 @@ The following HTML code is required to be somewhere in the webpage:
 </script>
 <script async type="text/javascript" src="/static/classisphere.js"></script>
 ```
-**To start in singleplayer instead, just use `arguments: [ {username} ],` instead**
-
-##### Variables
-* {username} - the player's username
-* {mppass} - if server verifies names, [mppass](https://wiki.vg/Classic_Protocol#User_Authentication). Otherwise leave as `''`.
-* {server ip} - the IP address of the server to connect to
-* {server port} - the port on the server to connect on (usually `'25565'`)
-
-### Complete example
 
 The links below show how to integrate the webclient into a simple website
 * [Flask (python webserver)](hosting-flask.md)
+
+### Building the webclient from source
+
+Run `make web dist` to package the compiled webclient into a `build/web/dist` folder, which can then be uploaded to a website.
+
+- By default the game is compiled to WebAssembly (`ClassiCube.js` and `ClassiCube.wasm`). Add `RELEASE=1` for optimised output.
+- Add `LEGACY=1` to produce a build equivalent to the webclient deployed to ClassiCube.net, a single optimised `ClassiCube.js` file (either asm.js or wasm2js depending on your emscripten version) that's slower but compatible with older browsers.
+- Make sure to run `make web clean` first when rebuilding with different flags/options.
+
+The folder contains a basic singleplayer webpage (`index.html`), the compiled game, and the texture pack (if `static/default.zip` exists). The game loads the texture pack from `/static/default.zip` at the website root, so upload the folder contents to the root (or see above for changing the url).
+
+#### Testing the local webclient build
+
+After compiling the webclient do `make web run`. This serves the compiled webclient on a local web server using emscripten's `emrun`, and then opens it in your browser.
+
+The webclient downloads the default texture pack from `/static/default.zip`, so you need to provide that file too. For example:
+```
+mkdir -p static
+curl -o static/default.zip https://classicube.net/static/default.zip
+```
+
+The generated ClassiCube.html page starts the game in singleplayer with the default username. To test multiplayer, you will need a webpage that provides server connection arguments.
+
+### Authentication
+
+The webclient has no login system built-in. The hosting webpage supplies the player's identity through `arguments`. To add authentication, sign the user in with your website's own account system, then generate the embed HTML with `arguments` filled in.
+
+The supported `arguments` forms are:
+- No arguments - opens singleplayer
+- 1 argument (username) - opens singleplayer as that player
+- 1 argument in the form `mc://[ip]:[port]/[username]/[mppass]` - connects to that server
+- 4 arguments (username, mppass, ip, port) - connects to that server (port is usually `'25565'`)
+
+If the server verifies names, the webpage must also calculate the correct [mppass](https://wiki.vg/Classic_Protocol#User_Authentication) for the user. Otherwise pass `''` for mppass.
+
+### Custom skin server
+
+Skins are downloaded from `http://cdn.classicube.net/skin/[player name].png` by default.
+Set the `http-skinserver` option to download from `[skin server]/[player name].png` instead.
+Multiplayer servers can also provide absolute URLs for player skins.
+
+NOTE: In a browser, skins only download successfully when the skin server:
+- sends CORS headers (e.g. `Access-Control-Allow-Origin: *`)
+- supports https:// when the webpage is https://
+
+### Page hooks
+
+The game js calls these functions on the webpage, when they are defined:
+- `forceTouchLayout()` - called on startup when the browser identifies as an Android or iOS device, so the webpage can switch to a mobile layout
+- `resizeGameCanvas()` - called when the window is resized or fullscreen is exited, so the webpage can adjust the canvas size
+
+### Storage
+
+Options and singleplayer maps are saved to the browser's IndexedDB storage, separately per website. Clearing the website's site data erases them.
+
+Players can also import their own map files into singleplayer through the Load level screen's Upload button, and export them as `.cw` downloads through the Save level screen.
 
 ### iOS / Android support
 

--- a/doc/hosting-webclient.md
+++ b/doc/hosting-webclient.md
@@ -16,6 +16,8 @@ NOTE: The generated ClassiCube.html page starts the game in singleplayer with th
 
 Run `make web dist` to package the compiled webclient into a `build/web/dist` folder, which can then be uploaded to a website. Add `RELEASE=1` for optimised output (run `make web clean` first if you previously compiled without it).
 
+Add `LEGACY=1` to instead produce a build equivalent to the webclient deployed to classicube.net, a single optimised `ClassiCube.js` file that also runs on older browsers. Run `make web clean` first when switching between build types.
+
 The folder contains a basic singleplayer webpage as `index.html`. For hosting your own version properly, keep reading below.
 
 Only the following 3 files are required:

--- a/doc/hosting-webclient.md
+++ b/doc/hosting-webclient.md
@@ -14,6 +14,10 @@ NOTE: The generated ClassiCube.html page starts the game in singleplayer with th
 
 ### Hosting the webclient
 
+Run `make web dist` to package the compiled webclient into a `build/web/dist` folder, which can then be uploaded to a website. Add `RELEASE=1` for optimised output (run `make web clean` first if you previously compiled without it).
+
+The folder contains a basic singleplayer webpage as `index.html`. For hosting your own version properly, keep reading below.
+
 Only the following 3 files are required:
 1) A web page to initialise the game .js and display the game
 2) The game .js file

--- a/doc/hosting-webclient.md
+++ b/doc/hosting-webclient.md
@@ -1,5 +1,19 @@
 Hosting your own version of the ClassiCube webclient is relatively straightforward
 
+### Testing the webclient locally
+
+After compiling the webclient do `make web run`. This serves the compiled webclient on a local web server using emscripten's `emrun`, and then opens it in your browser.
+
+The webclient downloads the default texture pack from `/static/default.zip`, so you need to provide that file too. For example:
+```
+mkdir -p static
+curl -o static/default.zip https://classicube.net/static/default.zip
+```
+
+NOTE: The generated ClassiCube.html page starts the game in singleplayer with the default username. To test multiplayer, you will need a webpage that provides server connection arguments.
+
+### Hosting the webclient
+
 Only the following 3 files are required:
 1) A web page to initialise the game .js and display the game
 2) The game .js file

--- a/doc/hosting-webclient.md
+++ b/doc/hosting-webclient.md
@@ -1,4 +1,4 @@
-Hosting your own version of the ClassiCube webclient is relatively straightforward
+Hosting your own version of the ClassiCube webclient is relatively straightforward.
 
 ### Testing the webclient locally
 
@@ -10,26 +10,28 @@ mkdir -p static
 curl -o static/default.zip https://classicube.net/static/default.zip
 ```
 
-NOTE: The generated ClassiCube.html page starts the game in singleplayer with the default username. To test multiplayer, you will need a webpage that provides server connection arguments.
+The generated ClassiCube.html page starts the game in singleplayer with the default username. To test multiplayer, you will need a webpage that provides server connection arguments.
 
 ### Hosting the webclient
 
-Run `make web dist` to package the compiled webclient into a `build/web/dist` folder, which can then be uploaded to a website. Add `RELEASE=1` for optimised output (run `make web clean` first if you previously compiled without it).
+Run `make web dist` to package the compiled webclient into a `build/web/dist` folder, which can then be uploaded to a website.
 
-Add `LEGACY=1` to instead produce a build equivalent to the webclient deployed to classicube.net, a single optimised `ClassiCube.js` file that also runs on older browsers. Run `make web clean` first when switching between build types.
+- By default the game is compiled to WebAssembly (`ClassiCube.js` and `ClassiCube.wasm`). Add `RELEASE=1` for optimised output.
+- Add `LEGACY=1` to produce a build equivalent to the webclient deployed to classicube.net, a single optimised `ClassiCube.js` file (either asm.js or wasm2js depending on your emscripten version) that's slower but compatible with older browsers.
+- Make sure to run `make web clean` first when rebuilding with different flags/options.
 
-The folder contains a basic singleplayer webpage as `index.html`. For hosting your own version properly, keep reading below.
-
-Only the following 3 files are required:
-1) A web page to initialise the game .js and display the game
-2) The game .js file
-3) The default texture pack
+The folder contains a basic singleplayer webpage (`index.html`), the compiled game, and the texture pack (if `static/default.zip` exists). The game loads the texture pack from `/static/default.zip` at the website root, so upload the folder contents to the root (or see below for changing the url).
 
 TODO: more advanced sample (authentication, custom game.js, skin server)
 
 ### Example setup
 
-For example, let's assume your website is setup like this:
+At minimum, a deployment needs 3 things:
+1) A web page to initialise the game .js and display the game
+2) The game .js file
+3) The default texture pack
+
+When building from source, `make web dist` provides all three. You can also rehost the prebuilt JS client from ClassiCube.net. For example, let's assume your website is setup like this:
 * `example.com/play.html`
 * `example.com/static/classisphere.js`
 * `example.com/static/default.zip`

--- a/misc/makefiles/web.mk
+++ b/misc/makefiles/web.mk
@@ -1,9 +1,10 @@
 SOURCE_DIRS := src src/webclient
 BUILD_DIR	:= build/web
 TARGET 		:= ClassiCube
+RUN_PROGRAM	?= emrun
 
 CFLAGS	:= -g
-LDFLAGS	:= -g -s WASM=1 -s NO_EXIT_RUNTIME=1 -s ABORTING_MALLOC=0 -s ALLOW_MEMORY_GROWTH=1 -s TOTAL_STACK=256Kb --js-library src/webclient/interop_web.js
+LDFLAGS	:= -g -s WASM=1 -s NO_EXIT_RUNTIME=1 -s ABORTING_MALLOC=0 -s ALLOW_MEMORY_GROWTH=1 -s TOTAL_STACK=256Kb --js-library src/webclient/interop_web.js --shell-file src/webclient/shell.html
 LIBS 	:=
 include misc/makefiles/common_config.mk
 
@@ -14,6 +15,9 @@ include misc/makefiles/common_config.mk
 CC      := emcc
 OEXT    := .html
 include misc/makefiles/common_build.mk
+
+# relink when the JS library or page shell changes too
+$(TARGET)$(OEXT): src/webclient/interop_web.js src/webclient/shell.html
 
 
 #---------------------------------------------------------------------------------

--- a/misc/makefiles/web.mk
+++ b/misc/makefiles/web.mk
@@ -24,3 +24,25 @@ $(TARGET)$(OEXT): src/webclient/interop_web.js src/webclient/shell.html
 # common targets
 #---------------------------------------------------------------------------------
 include misc/makefiles/common_targets.mk
+
+
+#---------------------------------------------------------------------------------
+# deployable folder generation
+#---------------------------------------------------------------------------------
+DIST_DIR := $(BUILD_DIR)/dist
+
+# Packages the webclient into a folder that can be uploaded to a website
+# The wheel event fix from doc/compile-fixes.md is applied to the game js
+.PHONY: dist
+dist: $(TARGET)$(OEXT)
+	rm -rf $(DIST_DIR)
+	mkdir -p $(DIST_DIR)/static
+	cp $(TARGET).html $(DIST_DIR)/index.html
+	cp $(TARGET).wasm $(DIST_DIR)/
+	sed 's#eventHandler.useCapture);#{ useCapture: eventHandler.useCapture, passive: false });#g' \
+	    $(TARGET).js > $(DIST_DIR)/$(TARGET).js
+	@if [ -f static/default.zip ]; then cp static/default.zip $(DIST_DIR)/static/; \
+	else echo "NOTE: Download https://classicube.net/static/default.zip into $(DIST_DIR)/static/"; fi
+	@echo "----------------------------------------------------"
+	@echo "Deployable webclient folder: $(DIST_DIR)"
+	@echo "----------------------------------------------------"

--- a/misc/makefiles/web.mk
+++ b/misc/makefiles/web.mk
@@ -3,8 +3,7 @@ BUILD_DIR	:= build/web
 TARGET 		:= ClassiCube
 RUN_PROGRAM	?= emrun
 
-# LEGACY=1 matches the webclient deployed to classicube.net, producing a
-#  single ClassiCube.js file that also runs on older browsers
+# LEGACY=1 matches the webclient deployed to classicube.net, slower but more compatible
 # NOTE: run 'make web clean' first when switching between build types
 ifdef LEGACY
 RELEASE  	:= 1

--- a/misc/makefiles/web.mk
+++ b/misc/makefiles/web.mk
@@ -3,8 +3,20 @@ BUILD_DIR	:= build/web
 TARGET 		:= ClassiCube
 RUN_PROGRAM	?= emrun
 
+# LEGACY=1 matches the webclient deployed to classicube.net, producing a
+#  single ClassiCube.js file that also runs on older browsers
+# NOTE: run 'make web clean' first when switching between build types
+ifdef LEGACY
+RELEASE  	:= 1
+OPT_LEVEL	:= s
+CFLAGS	:= -g2
+LDFLAGS	:= -g2 -Os -s WASM=0 -s SINGLE_FILE -s LEGACY_VM_SUPPORT=1 -s ENVIRONMENT=web
+else
 CFLAGS	:= -g
-LDFLAGS	:= -g -s WASM=1 -s NO_EXIT_RUNTIME=1 -s ABORTING_MALLOC=0 -s ALLOW_MEMORY_GROWTH=1 -s TOTAL_STACK=256Kb --js-library src/webclient/interop_web.js --shell-file src/webclient/shell.html
+LDFLAGS	:= -g -s WASM=1
+endif
+
+LDFLAGS	+= -s NO_EXIT_RUNTIME=1 -s ABORTING_MALLOC=0 -s ALLOW_MEMORY_GROWTH=1 -s TOTAL_STACK=256Kb --js-library src/webclient/interop_web.js --shell-file src/webclient/shell.html
 LIBS 	:=
 include misc/makefiles/common_config.mk
 
@@ -13,7 +25,12 @@ include misc/makefiles/common_config.mk
 # executable generation
 #---------------------------------------------------------------------------------
 CC      := emcc
+# LEGACY builds embed everything into one file, so must directly output .js
+ifdef LEGACY
+OEXT    := .js
+else
 OEXT    := .html
+endif
 include misc/makefiles/common_build.mk
 
 # relink when the JS library or page shell changes too
@@ -33,12 +50,13 @@ DIST_DIR := $(BUILD_DIR)/dist
 
 # Packages the webclient into a folder that can be uploaded to a website
 # The wheel event fix from doc/compile-fixes.md is applied to the game js
+# index.html is generated from the shell page, as LEGACY builds emit no .html
 .PHONY: dist
 dist: $(TARGET)$(OEXT)
 	rm -rf $(DIST_DIR)
 	mkdir -p $(DIST_DIR)/static
-	cp $(TARGET).html $(DIST_DIR)/index.html
-	cp $(TARGET).wasm $(DIST_DIR)/
+	sed 's#{{{ SCRIPT }}}#<script async type="text/javascript" src="$(TARGET).js"></script>#' src/webclient/shell.html > $(DIST_DIR)/index.html
+	@if [ -f $(TARGET).wasm ]; then cp $(TARGET).wasm $(DIST_DIR)/; fi
 	sed 's#eventHandler.useCapture);#{ useCapture: eventHandler.useCapture, passive: false });#g' \
 	    $(TARGET).js > $(DIST_DIR)/$(TARGET).js
 	@if [ -f static/default.zip ]; then cp static/default.zip $(DIST_DIR)/static/; \

--- a/readme.md
+++ b/readme.md
@@ -212,6 +212,10 @@ NOTE: If you are distributing a modified version, **please change the bundle ID 
     * `make web` - produces simple non-optimised output, easier to debug
     * `make web RELEASE=1` - produces optimised output, harder to debug
 
+You can also run `make web run` to compile the webclient and then serve it on a local web server using emscripten's `emrun`. [See here for details](doc/hosting-webclient.md#testing-the-webclient-locally)
+
+NOTE: On Windows, you will need to install GNU make (e.g. via `winget install ezwinports.make`), and then run `make web` from a shell where both make and emscripten are on the PATH (e.g. Git Bash)
+
 The generated javascript file has some issues. [See here for how to fix](doc/compile-fixes.md#webclient-patches)
 
 For details on how to integrate the webclient into a website, see [here](doc/hosting-webclient.md)

--- a/src/webclient/shell.html
+++ b/src/webclient/shell.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <title>ClassiCube</title>
+    <style>
+      body { margin: 0; padding: 0; background-color: #222222; }
+    </style>
+  </head>
+  <body>
+    <!-- the canvas *must not* have any border or padding, or mouse coords will be wrong -->
+    <canvas id="canvas" width="854" height="480" style="display:block; border:0; padding:0; margin:0 auto; width:854px; height:480px; background-color: black;"
+            oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
+
+    <script type='text/javascript'>
+      var canvas = document.getElementById('canvas');
+      // The game scales its UI by devicePixelRatio (see DisplayInfo.ScaleX in Window_Web.c)
+      // Backing store must be in physical pixels to avoid oversized/clipped UI.
+      var dpr = window.devicePixelRatio || 1;
+      canvas.width  = Math.round(854 * dpr);
+      canvas.height = Math.round(480 * dpr);
+
+      var Module = {
+        canvas:    canvas,
+        print:     function(text) { console.log(text); },
+        setStatus: function(text) { if (text) console.log(text); }
+      };
+    </script>
+    {{{ SCRIPT }}}
+  </body>
+</html>


### PR DESCRIPTION
Small changes that make it easier to build, run, and package the webclient locally.

Building:
- Speed up `make web` on Windows by using all processors

Running locally:
- Add `make web run` to compile the webclient and serves it from localhost with [emrun](https://emscripten.org/docs/compiling/Running-html-files-with-emrun.html).
- Added a shell page for local builds. The default emscripten page gives a 300x150 canvas (unplayable). The custom shell lets us default to 854x480 (usual minecraft size).

Packaging:
- Add `make web dist` to create a deployable folder under `./build/web/dist`. By default it's compatible with _recent_ versions of emscripten and targets WebAssembly. I added a `LEGACY=1` switch that compiles with the really old emscripten (targeting asm.js and IE-compatible) instead. With the legacy switch on it's the exact same command that build_webclient CI does.

Hosting:
- Improved docs, filling in the "advanced examples TODO"