### PR TITLE
fix virtual keyboard layout

### DIFF
--- a/src/VirtualKeyboard.h
+++ b/src/VirtualKeyboard.h
@@ -48,17 +48,17 @@ static struct KBLayout* kb;
 static const char* kb_normal_lower[] =
 {
 	"1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=", "Backspace",
-	"q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "(", ")", "&    ",
-	"a", "s", "d", "f", "g", "h", "j", "k", "l", "?", ";", "'", "Enter",
-	"z", "x", "c", "v", "b", "n", "m", ",", ".","\\", "!", "@", "/    ",
+	"q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "[", "]", "\\    ",
+	"a", "s", "d", "f", "g", "h", "j", "k", "l", ";", "'", "?", "Enter",
+	"z", "x", "c", "v", "b", "n", "m", ",", ".", "/", "!", "@", "/    ",
 	"Caps",0,0,0, "Shift",0,0,0, "Space",0,0,0, "Close"
 };
 static const char* kb_normal_upper[] =
 {
-	"1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "_", "+", "Backspace",
-	"Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P", "[", "]", "&   ",
-	"A", "S", "D", "F", "G", "H", "J", "K", "L", "?", ":", "\"", "Enter",
-	"Z", "X", "C", "V", "B", "N", "M", "<", ">", "*", "%", "#", "/    ",
+	"!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "+", "Backspace",
+	"Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P", "{", "}", "|    ",
+	"A", "S", "D", "F", "G", "H", "J", "K", "L", ":", "\"", "?", "Enter",
+	"Z", "X", "C", "V", "B", "N", "M", "<", ">", "?", "!", "@", "/    ",
 	"Caps",0,0,0, "Shift",0,0,0, "Space",0,0,0, "Close"
 };
 static const cc_uint8 kb_normal_behaviour[] =
@@ -214,10 +214,23 @@ static void VirtualKeyboard_Clamp(void) {
 static void VirtualKeyboard_Scroll(int xDelta, int yDelta) {
 	if (kb_curX < 0) kb_curX = 0;
 
+	// skip over empty keys when moving right
+	if (xDelta > 0 && kb_curX < kb->cellsPerRow - 1)
+		xDelta = KB_GetCellWidth(VirtualKeyboard_GetSelected());
+
 	kb_curX += xDelta;
 	kb_curY += yDelta;
-	
+
 	VirtualKeyboard_Clamp();
+
+	// Snap the position to the actual key to the left if it's over an empty one
+	int idx = kb_curX + kb->cellsPerRow * kb_curY;
+	while (KB_GetCellWidth(idx) == 0)
+	{
+		kb_curX--;
+		idx--;
+	}
+
 	KB_MarkDirty();
 }
 


### PR DESCRIPTION
I added more symbols to the virtual keyboard to mimic a standard QWERTY keyboard. I'm not sure what should be put in the extra spaces in the bottom left, so I chose a few commonly used symbols.

There's also a bug where the bottom row requires you to press left or right several times to navigate to the next key, since those keys are 4 spaces wide. I fixed that so it only takes one press to navigate just like the rest of the keys.