### PR TITLE
Add an option to enable/disable being able to send chat messages.

### DIFF
--- a/src/Gui.c
+++ b/src/Gui.c
@@ -116,6 +116,7 @@ static void LoadOptions(void) {
 	Gui.DefaultLines    = Game_ClassicMode ? 10 : 12;
 	Gui.Chatlines       = Options_GetInt(OPT_CHATLINES, 0, GUI_MAX_CHATLINES, Gui.DefaultLines);
 	Gui.ClickableChat   = !Game_ClassicMode && Options_GetBool(OPT_CLICKABLE_CHAT,   !Input_TouchMode);
+	Gui.MessageChat     = Options_GetBool(OPT_CHAT_MESSAGE, true);
 	Gui.TabAutocomplete = !Game_ClassicMode && Options_GetBool(OPT_TAB_AUTOCOMPLETE, true);
 
 	Gui.ClassicTexture   = Options_GetBool(OPT_CLASSIC_GUI,        true) || Game_ClassicMode;

--- a/src/Gui.h
+++ b/src/Gui.h
@@ -42,6 +42,8 @@ CC_VAR extern struct _GuiData {
 	int     Chatlines;
 	/* Whether clicking on a chatline inserts it into chat input. */
 	cc_bool ClickableChat;
+	/* Whether the player can send messages. */
+	cc_bool MessageChat;
 	/* Whether pressing tab in chat input attempts to autocomplete player names. */
 	cc_bool TabAutocomplete;
 	/* Whether FPS counter (and other info) is shown in top left. */

--- a/src/MenuOptions.c
+++ b/src/MenuOptions.c
@@ -864,6 +864,12 @@ static void    ChO_SetClickable(cc_bool v) {
 	Options_SetBool(OPT_CLICKABLE_CHAT, v); 
 }
 
+static cc_bool ChO_GetChatMessage(void) { return Gui.MessageChat; }
+static void    ChO_SetChatMessage(cc_bool v) {
+	Gui.MessageChat = v;
+	Options_SetBool(OPT_CHAT_MESSAGE, v);
+}
+
 static void ChatOptionsScreen_InitWidgets(struct MenuOptionsScreen* s) {
 	MenuOptionsScreen_BeginButtons(s);
 	{
@@ -880,6 +886,8 @@ static void ChatOptionsScreen_InitWidgets(struct MenuOptionsScreen* s) {
 			ChO_GetLogging,       ChO_SetLogging, NULL);
 		MenuOptionsScreen_AddBool(s, "Clickable chat",
 			ChO_GetClickable,     ChO_SetClickable, NULL);
+		MenuOptionsScreen_AddBool(s, "Sending messages",
+			ChO_GetChatMessage,   ChO_SetChatMessage, NULL);
 	}
 	MenuOptionsScreen_EndButtons(s, -1, Menu_SwitchOptions);
 }
@@ -1354,4 +1362,3 @@ static void NostalgiaFunctionalityScreen_InitWidgets(struct MenuOptionsScreen* s
 void NostalgiaFunctionalityScreen_Show(void) {
 	MenuOptionsScreen_Show(NostalgiaFunctionalityScreen_InitWidgets);
 }
-

--- a/src/Options.h
+++ b/src/Options.h
@@ -57,6 +57,7 @@ Copyright 2014-2025 ClassiCube | Licensed under BSD-3
 #define OPT_SHOW_FPS "gui-showfps"
 #define OPT_FONT_NAME "gui-fontname"
 #define OPT_BLACK_TEXT "gui-blacktextshadows"
+#define OPT_CHAT_MESSAGE "gui-chatmessage"
 
 #define OPT_LANDSCAPE_MODE "landscape-mode"
 #define OPT_CLASSIC_MODE "mode-classic"

--- a/src/Widgets.c
+++ b/src/Widgets.c
@@ -1887,7 +1887,14 @@ static void ChatInputWidget_OnPressedEnter(void* widget) {
 	/* Don't want trailing spaces in output message */
 	cc_string text = w->base.text;
 	String_UNSAFE_TrimEnd(&text);
-	if (text.length) { Chat_Send(&text, true); }
+
+	if (text.length) {
+		if (Gui.MessageChat || (!Gui.MessageChat && text.buffer[0] == '/')) {
+			Chat_Send(&text, true);
+		} else {
+			Chat_AddRaw("&cSending messages has been disabled in the settings.");
+		}
+	}
 
 	w->origStr.length = 0;
 	w->typingLogPos = Chat_InputLog.count; /* Index of newest entry + 1. */


### PR DESCRIPTION
Adds an option in the settings to be able to enable/disable sending messages in the chat.
It doesn't stop you from sending commands, however.

When it's disabled and you try to send a message it puts this local message in the chat:
<img width="537" height="88" alt="image" src="https://github.com/user-attachments/assets/e9c21118-9624-40a4-9fae-59908a067a13" />

